### PR TITLE
Toasts on failed login & password visibility toggle & no server field auto correct

### DIFF
--- a/app/src/main/java/com/dkanada/gramophone/ui/activities/LoginActivity.java
+++ b/app/src/main/java/com/dkanada/gramophone/ui/activities/LoginActivity.java
@@ -107,7 +107,7 @@ public class LoginActivity extends AbsBaseActivity implements View.OnClickListen
                 return;
             }
 
-            if (username.getText().toString().trim().length()==0) {
+            if (username.getText().toString().trim().length() == 0) {
                 Toast.makeText(context, context.getResources().getString(R.string.error_no_username), Toast.LENGTH_SHORT).show();
                 return;
             }

--- a/app/src/main/java/com/dkanada/gramophone/ui/activities/LoginActivity.java
+++ b/app/src/main/java/com/dkanada/gramophone/ui/activities/LoginActivity.java
@@ -107,7 +107,7 @@ public class LoginActivity extends AbsBaseActivity implements View.OnClickListen
                 return;
             }
 
-            if(username.getText().toString().trim().length()==0){
+            if (username.getText().toString().trim().length()==0) {
                 Toast.makeText(context, context.getResources().getString(R.string.error_no_username), Toast.LENGTH_SHORT).show();
                 return;
             }

--- a/app/src/main/java/com/dkanada/gramophone/ui/activities/LoginActivity.java
+++ b/app/src/main/java/com/dkanada/gramophone/ui/activities/LoginActivity.java
@@ -107,6 +107,11 @@ public class LoginActivity extends AbsBaseActivity implements View.OnClickListen
                 return;
             }
 
+            if(username.getText().toString().trim().length()==0){
+                Toast.makeText(context, context.getResources().getString(R.string.error_no_username), Toast.LENGTH_SHORT).show();
+                return;
+            }
+
             connectionManager.Connect(server.getText().toString(), new Response<ConnectionResult>() {
                 @Override
                 public void onResponse(ConnectionResult result) {
@@ -115,6 +120,7 @@ public class LoginActivity extends AbsBaseActivity implements View.OnClickListen
                     List<ServerInfo> servers = result.getServers();
 
                     if (servers.size() < 1) {
+                        Toast.makeText(context, context.getResources().getString(R.string.error_unreachable_server), Toast.LENGTH_SHORT).show();
                         return;
                     }
 
@@ -124,6 +130,11 @@ public class LoginActivity extends AbsBaseActivity implements View.OnClickListen
                         public void onResponse(AuthenticationResult result) {
                             if (result.getAccessToken() == null) return;
                             check(context, serverCredentials, result);
+                        }
+
+                        @Override
+                        public void onError(Exception exception) {
+                            Toast.makeText(context, context.getResources().getString(R.string.error_login_credentials), Toast.LENGTH_SHORT).show();
                         }
                     });
                 }

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     tools:context=".ui.activities.LoginActivity">
 
@@ -39,7 +40,8 @@
 
     <com.google.android.material.textfield.TextInputLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        app:endIconMode="password_toggle">
 
         <EditText
             android:id="@+id/password"
@@ -66,7 +68,7 @@
             android:layout_marginEnd="32dp"
             android:paddingTop="16dp"
             android:paddingBottom="16dp"
-            android:inputType="textShortMessage"
+            android:inputType="textNoSuggestions"
             android:hint="@string/server" />
 
     </com.google.android.material.textfield.TextInputLayout>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -149,6 +149,8 @@
     <string name="sort_method_artist">Artiste</string>
     <string name="sort_method_album">Album</string>
     <string name="sort_method_year">Année</string>
+    <string name="error_unreachable_server">Impossible de contacter le serveur.</string>
+    <string name="error_login_credentials">Identifiants de connexion invalides.</string>
     <string name="error_login_empty_addr">Veuillez saisir l\'adresse du serveur.</string>
     <string name="error_unexpected">Une erreur inattendue s\'est produite.</string>
     <string name="action_add_to_playlist">Ajouter à une playlist</string>
@@ -188,4 +190,5 @@
     <string name="source">Source</string>
     <string name="unlimited">Illimité</string>
     <string name="select_all_title">Sélectionner tout</string>
+    <string name="error_no_username">Veuillez saisir votre nom d\'utilisateur.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -214,7 +214,10 @@
     <string name="cancel_current_timer">Cancel current timer</string>
     <string name="sleep_timer_canceled">Sleep timer canceled.</string>
     <string name="sleep_timer_set">Sleep timer set for %d minutes from now.</string>
+    <string name="error_unreachable_server">Can\'t reach server.</string>
+    <string name="error_login_credentials">Invalid login credentials.</string>
     <string name="error_login_empty_addr">Please fill in the server address.</string>
     <string name="error_unexpected">An unexpected error occurred.</string>
+    <string name="error_no_username">Please fill in your username.</string>
 
 </resources>


### PR DESCRIPTION
I added two toasts: one when the server can't be reached (it also triggers when no login or password are filled but the server exists, should this edge case be fixed?) and one when login credentials are rejected by the server.

Fixes #13 