### PR TITLE
#22 Allow sorting by date added

### DIFF
--- a/app/src/main/java/com/dkanada/gramophone/adapter/album/AlbumAdapter.java
+++ b/app/src/main/java/com/dkanada/gramophone/adapter/album/AlbumAdapter.java
@@ -197,6 +197,8 @@ public class AlbumAdapter extends AbsMultiSelectAdapter<AlbumAdapter.ViewHolder,
                 break;
             case SortMethod.YEAR:
                 return MusicUtil.getYearString(dataSet.get(position).year);
+            case SortMethod.ADDED:
+                return "";
             case SortMethod.RANDOM:
                 return activity.getResources().getString(R.string.random);
         }

--- a/app/src/main/java/com/dkanada/gramophone/adapter/song/SongAdapter.java
+++ b/app/src/main/java/com/dkanada/gramophone/adapter/song/SongAdapter.java
@@ -202,6 +202,8 @@ public class SongAdapter extends AbsMultiSelectAdapter<SongAdapter.ViewHolder, S
                 break;
             case SortMethod.YEAR:
                 return MusicUtil.getYearString(dataSet.get(position).year);
+            case SortMethod.ADDED:
+                return "";
             case SortMethod.RANDOM:
                 return activity.getResources().getString(R.string.random);
         }

--- a/app/src/main/java/com/dkanada/gramophone/helper/sort/SortMethod.java
+++ b/app/src/main/java/com/dkanada/gramophone/helper/sort/SortMethod.java
@@ -5,5 +5,6 @@ public class SortMethod {
     public static final String ALBUM = "ALBUM";
     public static final String ARTIST = "ARTIST";
     public static final String YEAR = "YEAR";
+    public static final String ADDED = "ADDED";
     public static final String RANDOM = "RANDOM";
 }

--- a/app/src/main/java/com/dkanada/gramophone/ui/fragments/mainactivity/library/LibraryFragment.java
+++ b/app/src/main/java/com/dkanada/gramophone/ui/fragments/mainactivity/library/LibraryFragment.java
@@ -368,7 +368,9 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
                     .setChecked(currentSortMethod.equals(SortMethod.ARTIST));
             sortMethodMenu.add(0, R.id.action_sort_method_year, 2, R.string.sort_method_year)
                     .setChecked(currentSortMethod.equals(SortMethod.YEAR));
-            sortMethodMenu.add(0, R.id.action_sort_method_random, 3, R.string.sort_method_random)
+            sortMethodMenu.add(0, R.id.action_sort_method_added, 3, R.string.sort_method_added)
+                    .setChecked(currentSortMethod.equals(SortMethod.ADDED));
+            sortMethodMenu.add(0, R.id.action_sort_method_random, 4, R.string.sort_method_random)
                     .setChecked(currentSortMethod.equals(SortMethod.RANDOM));
         } else if (fragment instanceof SongsFragment) {
             sortMethodMenu.add(0, R.id.action_sort_method_name, 0, R.string.sort_method_name)
@@ -379,7 +381,9 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
                     .setChecked(currentSortMethod.equals(SortMethod.ARTIST));
             sortMethodMenu.add(0, R.id.action_sort_method_year, 3, R.string.sort_method_year)
                     .setChecked(currentSortMethod.equals(SortMethod.YEAR));
-            sortMethodMenu.add(0, R.id.action_sort_method_random, 4, R.string.sort_method_random)
+            sortMethodMenu.add(0, R.id.action_sort_method_added, 4, R.string.sort_method_added)
+                    .setChecked(currentSortMethod.equals(SortMethod.ADDED));
+            sortMethodMenu.add(0, R.id.action_sort_method_random, 5, R.string.sort_method_random)
                     .setChecked(currentSortMethod.equals(SortMethod.RANDOM));
         }
 
@@ -412,6 +416,9 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
                 break;
             case R.id.action_sort_method_year:
                 sortMethod = SortMethod.YEAR;
+                break;
+            case R.id.action_sort_method_added:
+                sortMethod = SortMethod.ADDED;
                 break;
             case R.id.action_sort_method_random:
                 sortMethod = SortMethod.RANDOM;

--- a/app/src/main/java/com/dkanada/gramophone/ui/fragments/mainactivity/library/pager/AbsLibraryPagerRecyclerViewCustomGridSizeFragment.java
+++ b/app/src/main/java/com/dkanada/gramophone/ui/fragments/mainactivity/library/pager/AbsLibraryPagerRecyclerViewCustomGridSizeFragment.java
@@ -82,6 +82,7 @@ public abstract class AbsLibraryPagerRecyclerViewCustomGridSizeFragment<A extend
         this.sortMethod = sortMethod;
         saveSortMethod(sortMethod);
         setSortMethod(sortMethod);
+        invalidateAdapter();
     }
 
     public boolean canUsePalette() {

--- a/app/src/main/java/com/dkanada/gramophone/ui/fragments/mainactivity/library/pager/AlbumsFragment.java
+++ b/app/src/main/java/com/dkanada/gramophone/ui/fragments/mainactivity/library/pager/AlbumsFragment.java
@@ -38,6 +38,7 @@ public class AlbumsFragment extends AbsLibraryPagerRecyclerViewCustomGridSizeFra
         QueryUtil.getAlbums(new ItemQuery(), new MediaCallback() {
             @Override
             public void onLoadMedia(List<?> media) {
+                dataSet.clear();
                 dataSet.addAll((Collection<Album>) media);
                 adapter.notifyDataSetChanged();
             }

--- a/app/src/main/java/com/dkanada/gramophone/ui/fragments/mainactivity/library/pager/SongsFragment.java
+++ b/app/src/main/java/com/dkanada/gramophone/ui/fragments/mainactivity/library/pager/SongsFragment.java
@@ -58,6 +58,7 @@ public class SongsFragment extends AbsLibraryPagerRecyclerViewCustomGridSizeFrag
         QueryUtil.getSongs(new ItemQuery(), new MediaCallback() {
             @Override
             public void onLoadMedia(List<?> media) {
+                dataSet.clear();
                 dataSet.addAll((Collection<Song>) media);
                 adapter.notifyDataSetChanged();
             }

--- a/app/src/main/java/com/dkanada/gramophone/util/QueryUtil.java
+++ b/app/src/main/java/com/dkanada/gramophone/util/QueryUtil.java
@@ -12,6 +12,7 @@ import com.dkanada.gramophone.model.Song;
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.dto.BaseItemType;
+import org.jellyfin.apiclient.model.entities.SortOrder;
 import org.jellyfin.apiclient.model.querying.ArtistsQuery;
 import org.jellyfin.apiclient.model.querying.ItemFields;
 import org.jellyfin.apiclient.model.querying.ItemQuery;
@@ -220,6 +221,9 @@ public class QueryUtil {
                 break;
             case SortMethod.YEAR:
                 query.setSortBy(new String[]{"ProductionYear"});
+                break;
+            case SortMethod.ADDED:
+                query.setSortBy(new String[]{"DateCreated"});
                 break;
             case SortMethod.RANDOM:
                 query.setSortBy(new String[]{"Random"});

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -10,6 +10,7 @@
     <item name="action_sort_method_album" type="id" />
     <item name="action_sort_method_artist" type="id" />
     <item name="action_sort_method_year" type="id" />
+    <item name="action_sort_method_added" type="id" />
     <item name="action_sort_method_random" type="id" />
 
     <item name="action_multi_select_adapter_check_all" type="id" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -208,6 +208,7 @@
     <string name="sort_method_artist">Artist</string>
     <string name="sort_method_album">Album</string>
     <string name="sort_method_year">Year</string>
+    <string name="sort_method_added">Added</string>
     <string name="sort_method_random">Random</string>
 
     <string name="finish_current_music_sleep_timer">Finish last song</string>


### PR DESCRIPTION
Adds option to sort by date added (actually "date created" in the API) - hardcoded to descending for now (most recently added first).

Also adds refreshing of songs and albums when sort order is modified. 