### PR TITLE
Replace QueueStore SQL with json save/load in PreferenceUtil

### DIFF
--- a/app/src/main/java/com/dkanada/gramophone/provider/QueueStore.java
+++ b/app/src/main/java/com/dkanada/gramophone/provider/QueueStore.java
@@ -1,189 +1,65 @@
 /*
-* Copyright (C) 2014 The CyanogenMod Project
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (C) 2014 The CyanogenMod Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.dkanada.gramophone.provider;
 
-import android.content.ContentValues;
 import android.content.Context;
-import android.database.Cursor;
-import android.database.sqlite.SQLiteDatabase;
-import android.database.sqlite.SQLiteOpenHelper;
-import android.provider.BaseColumns;
-import android.provider.MediaStore.Audio.AudioColumns;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.dkanada.gramophone.App;
-import com.dkanada.gramophone.loader.SongLoader;
 import com.dkanada.gramophone.model.Song;
 import com.dkanada.gramophone.util.PreferenceUtil;
 
-import java.util.ArrayList;
 import java.util.List;
 
-public class QueueStore extends SQLiteOpenHelper {
+public class QueueStore {
     @Nullable
-    private static QueueStore sInstance = null;
-    public static final String DATABASE_NAME = "music_playback_state.db";
-    public static final String PLAYING_QUEUE_TABLE_NAME = "playing_queue";
-    public static final String ORIGINAL_PLAYING_QUEUE_TABLE_NAME = "original_playing_queue";
-    private static final int VERSION = 5;
+    private static QueueStore instance = null;
 
-    public QueueStore(final Context context) {
-        super(context, DATABASE_NAME, null, VERSION);
-    }
+    private final Context context;
 
-    @Override
-    public void onCreate(@NonNull final SQLiteDatabase db) {
-        createTable(db, PLAYING_QUEUE_TABLE_NAME);
-        createTable(db, ORIGINAL_PLAYING_QUEUE_TABLE_NAME);
-    }
-
-    private void createTable(@NonNull final SQLiteDatabase db, final String tableName) {
-        // noinspection StringBufferReplaceableByString
-        StringBuilder builder = new StringBuilder();
-        builder.append("CREATE TABLE IF NOT EXISTS ");
-        builder.append(tableName);
-        builder.append("(");
-
-        builder.append(BaseColumns._ID);
-        builder.append(" INT NOT NULL,");
-
-        builder.append(AudioColumns.TITLE);
-        builder.append(" STRING NOT NULL,");
-
-        builder.append(AudioColumns.TRACK);
-        builder.append(" INT NOT NULL,");
-
-        builder.append(AudioColumns.YEAR);
-        builder.append(" INT NOT NULL,");
-
-        builder.append(AudioColumns.DURATION);
-        builder.append(" LONG NOT NULL,");
-
-        builder.append(AudioColumns.ALBUM_ID);
-        builder.append(" INT NOT NULL,");
-
-        builder.append(AudioColumns.ALBUM);
-        builder.append(" STRING NOT NULL,");
-
-        builder.append(AudioColumns.ARTIST_ID);
-        builder.append(" INT NOT NULL,");
-
-        builder.append(AudioColumns.ARTIST);
-        builder.append(" STRING NOT NULL,");
-
-        builder.append(SongLoader.QUEUE_PRIMARY);
-        builder.append(" STRING NOT NULL,");
-
-        builder.append(SongLoader.QUEUE_FAVORITE);
-        builder.append(" STRING NOT NULL);");
-
-        db.execSQL(builder.toString());
-    }
-
-    @Override
-    public void onUpgrade(@NonNull final SQLiteDatabase db, final int oldVersion, final int newVersion) {
-        db.execSQL("DROP TABLE IF EXISTS " + PLAYING_QUEUE_TABLE_NAME);
-        db.execSQL("DROP TABLE IF EXISTS " + ORIGINAL_PLAYING_QUEUE_TABLE_NAME);
-        onCreate(db);
-    }
-
-    @Override
-    public void onDowngrade(@NonNull SQLiteDatabase db, int oldVersion, int newVersion) {
-        db.execSQL("DROP TABLE IF EXISTS " + PLAYING_QUEUE_TABLE_NAME);
-        db.execSQL("DROP TABLE IF EXISTS " + ORIGINAL_PLAYING_QUEUE_TABLE_NAME);
-        onCreate(db);
+    private QueueStore(final Context context) {
+        this.context = context;
     }
 
     @NonNull
     public static synchronized QueueStore getInstance(@NonNull final Context context) {
-        if (sInstance == null) {
-            sInstance = new QueueStore(context.getApplicationContext());
+        if (instance == null) {
+            instance = new QueueStore(context.getApplicationContext());
         }
 
-        return sInstance;
+        return instance;
     }
 
     public synchronized void saveQueues(@NonNull final List<Song> playingQueue, @NonNull final List<Song> originalPlayingQueue) {
-        saveQueue(PLAYING_QUEUE_TABLE_NAME, playingQueue);
-        saveQueue(ORIGINAL_PLAYING_QUEUE_TABLE_NAME, originalPlayingQueue);
-    }
+        PreferenceUtil preferenceUtil = PreferenceUtil.getInstance(App.getInstance());
 
-    private synchronized void saveQueue(final String tableName, @NonNull final List<Song> queue) {
-        final SQLiteDatabase database = getWritableDatabase();
-        database.beginTransaction();
-
-        try {
-            database.delete(tableName, null, null);
-            database.setTransactionSuccessful();
-        } finally {
-            database.endTransaction();
-        }
-
-        final int NUM_PROCESS = 20;
-        int position = 0;
-        while (position < queue.size()) {
-            database.beginTransaction();
-            try {
-                for (int i = position; i < queue.size() && i < position + NUM_PROCESS; i++) {
-                    Song song = queue.get(i);
-                    ContentValues values = new ContentValues(4);
-
-                    values.put(BaseColumns._ID, song.id);
-                    values.put(AudioColumns.TITLE, song.title);
-                    values.put(AudioColumns.TRACK, song.trackNumber);
-                    values.put(AudioColumns.YEAR, song.year);
-                    values.put(AudioColumns.DURATION, song.duration);
-                    values.put(AudioColumns.ALBUM_ID, song.albumId);
-                    values.put(AudioColumns.ALBUM, song.albumName);
-                    values.put(AudioColumns.ARTIST_ID, song.artistId);
-                    values.put(AudioColumns.ARTIST, song.artistName);
-                    values.put(SongLoader.QUEUE_PRIMARY, song.primary);
-                    values.put(SongLoader.QUEUE_FAVORITE, song.favorite);
-
-                    database.insert(tableName, null, values);
-                }
-
-                database.setTransactionSuccessful();
-            } finally {
-                database.endTransaction();
-                position += NUM_PROCESS;
-            }
-        }
+        preferenceUtil.savePlayingQueue(playingQueue);
+        preferenceUtil.saveOriginalPlayingQueue(originalPlayingQueue);
     }
 
     @NonNull
     public List<Song> getSavedPlayingQueue() {
-        return getQueue(PLAYING_QUEUE_TABLE_NAME);
+        return PreferenceUtil.getInstance(App.getInstance()).getPlayingQueue();
     }
 
     @NonNull
     public List<Song> getSavedOriginalPlayingQueue() {
-        return getQueue(ORIGINAL_PLAYING_QUEUE_TABLE_NAME);
-    }
-
-    @NonNull
-    private List<Song> getQueue(@NonNull final String tableName) {
-        if (!PreferenceUtil.getInstance(App.getInstance()).getRememberQueue()) {
-            return new ArrayList<>();
-        }
-
-        Cursor cursor = getReadableDatabase().query(tableName, null,
-                null, null, null, null, null);
-        return SongLoader.getSongs(cursor);
+        return PreferenceUtil.getInstance(App.getInstance()).getOriginalPlayingQueue();
     }
 }

--- a/app/src/main/java/com/dkanada/gramophone/ui/fragments/mainactivity/library/pager/AbsLibraryPagerRecyclerViewFragment.java
+++ b/app/src/main/java/com/dkanada/gramophone/ui/fragments/mainactivity/library/pager/AbsLibraryPagerRecyclerViewFragment.java
@@ -1,11 +1,11 @@
 package com.dkanada.gramophone.ui.fragments.mainactivity.library.pager;
 
 import android.os.Bundle;
-import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 
 import com.dkanada.gramophone.App;
+import com.dkanada.gramophone.databinding.FragmentMainActivityRecyclerViewBinding;
 import com.dkanada.gramophone.util.PreferenceUtil;
 import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.appbar.AppBarLayout.OnOffsetChangedListener;
@@ -16,27 +16,13 @@ import androidx.recyclerview.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.TextView;
 
 import com.kabouzeid.appthemehelper.ThemeStore;
 import com.dkanada.gramophone.R;
 import com.dkanada.gramophone.util.ViewUtil;
-import com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView;
-
-import butterknife.BindView;
-import butterknife.ButterKnife;
-import butterknife.Unbinder;
 
 public abstract class AbsLibraryPagerRecyclerViewFragment<A extends RecyclerView.Adapter, L extends RecyclerView.LayoutManager, Q> extends AbsLibraryPagerFragment implements OnOffsetChangedListener {
-
-    private Unbinder unbinder;
-
-    @BindView(R.id.container)
-    View container;
-    @BindView(R.id.recycler_view)
-    RecyclerView recyclerView;
-    @BindView(android.R.id.empty)
-    TextView empty;
+    private FragmentMainActivityRecyclerViewBinding binding;
 
     private A adapter;
     private L layoutManager;
@@ -47,13 +33,13 @@ public abstract class AbsLibraryPagerRecyclerViewFragment<A extends RecyclerView
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        View view = inflater.inflate(getLayoutRes(), container, false);
-        unbinder = ButterKnife.bind(this, view);
-        return view;
+        binding = FragmentMainActivityRecyclerViewBinding.inflate(inflater);
+
+        return binding.getRoot();
     }
 
     @Override
-    public void onViewCreated(View view, Bundle savedInstanceState) {
+    public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
         getLibraryFragment().addOnAppBarOffsetChangedListener(this);
@@ -86,29 +72,27 @@ public abstract class AbsLibraryPagerRecyclerViewFragment<A extends RecyclerView
     }
 
     private void initRecyclerView() {
-        if (recyclerView instanceof FastScrollRecyclerView) {
-            ViewUtil.setUpFastScrollRecyclerViewColor(getActivity(), ((FastScrollRecyclerView) recyclerView), ThemeStore.accentColor(getActivity()));
-        }
+        ViewUtil.setUpFastScrollRecyclerViewColor(getActivity(), binding.recyclerView, ThemeStore.accentColor(getActivity()));
 
-        recyclerView.setLayoutManager(layoutManager);
-        recyclerView.setAdapter(adapter);
+        binding.recyclerView.setLayoutManager(layoutManager);
+        binding.recyclerView.setAdapter(adapter);
     }
 
     protected void invalidateAdapter() {
         initAdapter();
         initQuery();
 
-        recyclerView.setAdapter(adapter);
+        binding.recyclerView.setAdapter(adapter);
         loadItems(0);
     }
 
     protected void invalidateLayoutManager() {
         initLayoutManager();
-        recyclerView.setLayoutManager(layoutManager);
+        binding.recyclerView.setLayoutManager(layoutManager);
     }
 
     protected RecyclerView getRecyclerView() {
-        return recyclerView;
+        return binding.recyclerView;
     }
 
     protected A getAdapter() {
@@ -128,11 +112,6 @@ public abstract class AbsLibraryPagerRecyclerViewFragment<A extends RecyclerView
         return R.string.empty;
     }
 
-    @LayoutRes
-    protected int getLayoutRes() {
-        return R.layout.fragment_main_activity_recycler_view;
-    }
-
     @NonNull
     protected abstract A createAdapter();
 
@@ -146,7 +125,11 @@ public abstract class AbsLibraryPagerRecyclerViewFragment<A extends RecyclerView
 
     @Override
     public void onOffsetChanged(AppBarLayout appBarLayout, int i) {
-        container.setPadding(container.getPaddingLeft(), container.getPaddingTop(), container.getPaddingRight(), getLibraryFragment().getTotalAppBarScrollingRange() + i);
+        binding.container.setPadding(
+                binding.container.getPaddingLeft(),
+                binding.container.getPaddingTop(),
+                binding.container.getPaddingRight(),
+                getLibraryFragment().getTotalAppBarScrollingRange() + i);
 
         int last = 0;
         if (!loading && getLayoutManager() instanceof GridLayoutManager) {
@@ -172,13 +155,10 @@ public abstract class AbsLibraryPagerRecyclerViewFragment<A extends RecyclerView
         super.onDestroyView();
 
         getLibraryFragment().removeOnAppBarOffsetChangedListener(this);
-        unbinder.unbind();
     }
 
     private void checkIsEmpty() {
-        if (empty != null) {
-            empty.setText(getEmptyMessage());
-            empty.setVisibility(adapter == null || adapter.getItemCount() == 0 ? View.VISIBLE : View.GONE);
-        }
+        binding.empty.setText(getEmptyMessage());
+        binding.empty.setVisibility(adapter == null || adapter.getItemCount() == 0 ? View.VISIBLE : View.GONE);
     }
 }

--- a/app/src/main/java/com/dkanada/gramophone/util/PreferenceUtil.java
+++ b/app/src/main/java/com/dkanada/gramophone/util/PreferenceUtil.java
@@ -7,6 +7,7 @@ import android.preference.PreferenceManager;
 
 import androidx.annotation.StyleRes;
 
+import com.dkanada.gramophone.model.Song;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
@@ -20,6 +21,7 @@ import com.dkanada.gramophone.ui.fragments.player.NowPlayingScreen;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -81,6 +83,9 @@ public final class PreferenceUtil {
     public static final String SLEEP_TIMER_LAST_VALUE = "sleep_timer_last_value";
     public static final String SLEEP_TIMER_ELAPSED_REALTIME = "sleep_timer_elapsed_real_time";
     public static final String SLEEP_TIMER_FINISH_SONG = "sleep_timer_finish_music";
+
+    public static final String PLAYING_QUEUE = "playing_queue";
+    public static final String ORIGINAL_PLAYING_QUEUE = "original_playing_queue";
 
     private static PreferenceUtil sInstance;
 
@@ -205,6 +210,50 @@ public final class PreferenceUtil {
 
     public final boolean getRememberQueue() {
         return mPreferences.getBoolean(REMEMBER_QUEUE, true);
+    }
+
+    public void savePlayingQueue(List<Song> playingQueue) {
+        saveQueue(playingQueue, PLAYING_QUEUE);
+    }
+
+    public void saveOriginalPlayingQueue(List<Song> originalPlayingQueue) {
+        saveQueue(originalPlayingQueue, ORIGINAL_PLAYING_QUEUE);
+    }
+
+    private void saveQueue(List<Song> queue, String key) {
+        if (!getRememberQueue()) return;
+
+        Song[] queueArray = queue.toArray(new Song[queue.size()]);
+
+        Gson gson = new Gson();
+        String json = gson.toJson(queueArray);
+
+        mPreferences.edit().putString(key, json).apply();
+    }
+
+    public List<Song> getPlayingQueue() {
+        return getQueue(PLAYING_QUEUE);
+    }
+
+    public List<Song> getOriginalPlayingQueue() {
+        return getQueue(ORIGINAL_PLAYING_QUEUE);
+    }
+
+    private List<Song> getQueue(String key) {
+        if (!getRememberQueue()) {
+            return new ArrayList<>();
+        }
+
+        String json = mPreferences.getString(key, "");
+        if (json.equals("")) {
+            return new ArrayList<>();
+        }
+
+        Gson gson = new Gson();
+        Type savedQueueType = new TypeToken<Song[]>() {}.getType();
+
+        Song[] queueArray = gson.fromJson(json, savedQueueType);
+        return Arrays.asList(queueArray);
     }
 
     public final boolean getShowAlbumCover() {


### PR DESCRIPTION
The song details dialog you added is nice, but it crashes Gelli if you try to view details on a song in the queue that has been loaded at Gelli startup.

This is because the queue sql only saves a subset of the of the properties of each Song and we get a npe when accessing one of them. 

Fixing this lead to ripping out the entire sql queue storage and replacing it with a simple json save/load mechanism in PreferenceUtil. Let me know what you think.  I'm marking it as draft because it probably needs some cleanup, but the queue save/load works.