### PR TITLE
Fix location of Glide cache

### DIFF
--- a/app/src/main/java/com/dkanada/gramophone/glide/CustomGlideModule.java
+++ b/app/src/main/java/com/dkanada/gramophone/glide/CustomGlideModule.java
@@ -23,10 +23,10 @@ import java.io.File;
 public class CustomGlideModule extends AppGlideModule {
     @Override
     public void applyOptions(@NonNull Context context, GlideBuilder builder) {
-        File file = new File(context.getCacheDir() + "glide");
+        File cacheDir = new File(context.getCacheDir(), "glide");
         int size = PreferenceUtil.getInstance(context).getImageCacheSize();
 
-        builder.setDiskCache(new DiskLruCacheFactory(() -> file, size));
+        builder.setDiskCache(new DiskLruCacheFactory(() -> cacheDir, size));
         builder.setDefaultRequestOptions(new RequestOptions().format(DecodeFormat.PREFER_RGB_565));
     }
 


### PR DESCRIPTION
`context.getCacheDir() + "glide"` resulted in `cacheglide` to be used instead of `cache/glide`. This PR fixes that by using the `File parent, String child` contructor of `File`.