### PR TITLE
Refactor: Let ExoPlayer handle audio focus

### DIFF
--- a/app/src/main/java/com/dkanada/gramophone/service/MusicService.java
+++ b/app/src/main/java/com/dkanada/gramophone/service/MusicService.java
@@ -107,9 +107,6 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
     public static final int PLAY_SONG = 3;
     public static final int PREPARE_NEXT = 4;
     public static final int SET_POSITION = 5;
-    public static final int FOCUS_CHANGE = 6;
-    public static final int DUCK = 7;
-    public static final int UNDUCK = 8;
 
     public static final int SHUFFLE_MODE_NONE = 0;
     public static final int SHUFFLE_MODE_SHUFFLE = 1;
@@ -142,10 +139,8 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
 
     private boolean notHandledMetaChangedForCurrentTrack;
     private boolean queuesRestored;
-    private boolean pausedByTransientLossOfFocus;
 
     private PlayingNotification playingNotification;
-    private AudioManager audioManager;
     private MediaSessionCompat mediaSession;
     private PowerManager.WakeLock wakeLock;
 
@@ -185,13 +180,6 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
                     appWidgetCard.notifyChange(MusicService.this, META_CHANGED, ids);
                     break;
             }
-        }
-    };
-
-    private final AudioManager.OnAudioFocusChangeListener audioFocusListener = new AudioManager.OnAudioFocusChangeListener() {
-        @Override
-        public void onAudioFocusChange(final int focusChange) {
-            playerHandler.obtainMessage(FOCUS_CHANGE, focusChange, 0).sendToTarget();
         }
     };
 
@@ -239,14 +227,6 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
         restoreState();
 
         mediaSession.setActive(true);
-    }
-
-    private AudioManager getAudioManager() {
-        if (audioManager == null) {
-            audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
-        }
-
-        return audioManager;
     }
 
     private void initMediaSession() {
@@ -458,7 +438,6 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
         pause();
         playingNotification.stop();
 
-        getAudioManager().abandonAudioFocus(audioFocusListener);
         stopSelf();
     }
 
@@ -524,10 +503,6 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
             nextPosition = getNextPosition(false);
             playback.queueDataSource(getSongAt(nextPosition));
         }
-    }
-
-    private boolean requestFocus() {
-        return getAudioManager().requestAudioFocus(audioFocusListener, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED;
     }
 
     public void initNotification() {
@@ -805,7 +780,6 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
     }
 
     public void pause() {
-        pausedByTransientLossOfFocus = false;
         if (playback.isPlaying()) {
             playback.pause();
             notifyChange(STATE_CHANGED);
@@ -814,27 +788,18 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
 
     public void play() {
         synchronized (this) {
-            if (requestFocus()) {
-                if (!playback.isPlaying()) {
-                    if (!playback.isReady()) {
-                        playSongAt(getPosition());
-                    } else {
-                        playback.start();
-                        if (notHandledMetaChangedForCurrentTrack) {
-                            handleChangeInternal(META_CHANGED);
-                            notHandledMetaChangedForCurrentTrack = false;
-                        }
-
-                        notifyChange(STATE_CHANGED);
-
-                        // fixes a bug where the volume would stay ducked
-                        // happens when audio focus GAIN event not sent
-                        playerHandler.removeMessages(DUCK);
-                        playerHandler.sendEmptyMessage(UNDUCK);
+            if (!playback.isPlaying()) {
+                if (!playback.isReady()) {
+                    playSongAt(getPosition());
+                } else {
+                    playback.start();
+                    if (notHandledMetaChangedForCurrentTrack) {
+                        handleChangeInternal(META_CHANGED);
+                        notHandledMetaChangedForCurrentTrack = false;
                     }
+
+                    notifyChange(STATE_CHANGED);
                 }
-            } else {
-                Toast.makeText(this, getResources().getString(R.string.audio_focus_denied), Toast.LENGTH_SHORT).show();
             }
         }
     }
@@ -1065,7 +1030,6 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
 
     private static final class PlaybackHandler extends Handler {
         private final WeakReference<MusicService> mService;
-        private int currentDuckVolume = 100;
 
         public PlaybackHandler(final MusicService service, @NonNull final Looper looper) {
             super(looper);
@@ -1080,36 +1044,6 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
             }
 
             switch (msg.what) {
-                case DUCK:
-                    if (PreferenceUtil.getInstance(service).getAudioDucking()) {
-                        currentDuckVolume -= 5;
-                        if (currentDuckVolume > 20) {
-                            sendEmptyMessageDelayed(DUCK, 10);
-                        } else {
-                            currentDuckVolume = 20;
-                        }
-                    } else {
-                        currentDuckVolume = 100;
-                    }
-
-                    service.playback.setVolume(currentDuckVolume);
-                    break;
-
-                case UNDUCK:
-                    if (PreferenceUtil.getInstance(service).getAudioDucking()) {
-                        currentDuckVolume += 3;
-                        if (currentDuckVolume < 100) {
-                            sendEmptyMessageDelayed(UNDUCK, 10);
-                        } else {
-                            currentDuckVolume = 100;
-                        }
-                    } else {
-                        currentDuckVolume = 100;
-                    }
-
-                    service.playback.setVolume(currentDuckVolume);
-                    break;
-
                 case TRACK_CHANGED:
                     if (service.getRepeatMode() == REPEAT_MODE_NONE && service.isLastTrack()) {
                         service.pause();
@@ -1156,40 +1090,6 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
 
                 case PREPARE_NEXT:
                     service.prepareNextImpl();
-                    break;
-
-                case FOCUS_CHANGE:
-                    switch (msg.arg1) {
-                        case AudioManager.AUDIOFOCUS_GAIN:
-                            if (!service.isPlaying() && service.pausedByTransientLossOfFocus) {
-                                service.play();
-                                service.pausedByTransientLossOfFocus = false;
-                            }
-                            removeMessages(DUCK);
-                            sendEmptyMessage(UNDUCK);
-                            break;
-
-                        case AudioManager.AUDIOFOCUS_LOSS:
-                            // Lost focus for an unbounded amount of time: stop playback and release media playback
-                            service.pause();
-                            break;
-
-                        case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
-                            // Lost focus for a short time, but we have to stop
-                            // playback. We don't release the media playback because playback
-                            // is likely to resume
-                            boolean wasPlaying = service.isPlaying();
-                            service.pause();
-                            service.pausedByTransientLossOfFocus = wasPlaying;
-                            break;
-
-                        case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK:
-                            // Lost focus for a short time, but it's ok to keep playing
-                            // at an attenuated level
-                            removeMessages(UNDUCK);
-                            sendEmptyMessage(DUCK);
-                            break;
-                    }
                     break;
             }
         }

--- a/app/src/main/java/com/dkanada/gramophone/service/playback/LocalPlayer.java
+++ b/app/src/main/java/com/dkanada/gramophone/service/playback/LocalPlayer.java
@@ -85,11 +85,14 @@ public class LocalPlayer implements Playback {
 
         MediaSourceFactory mediaSourceFactory = new UnknownMediaSourceFactory(buildDataSourceFactory());
         AudioAttributes audioAttributes = new AudioAttributes.Builder()
-                .setUsage(C.USAGE_MEDIA)
-                .setContentType(C.CONTENT_TYPE_MUSIC)
-                .build();
+            .setUsage(C.USAGE_MEDIA)
+            .setContentType(C.CONTENT_TYPE_MUSIC)
+            .build();
 
-        exoPlayer = new SimpleExoPlayer.Builder(context).setMediaSourceFactory(mediaSourceFactory).setAudioAttributes(audioAttributes, true).build();
+        exoPlayer = new SimpleExoPlayer.Builder(context)
+            .setMediaSourceFactory(mediaSourceFactory)
+            .setAudioAttributes(audioAttributes, true)
+            .build();
 
         exoPlayer.addListener(eventListener);
         exoPlayer.prepare();

--- a/app/src/main/java/com/dkanada/gramophone/service/playback/LocalPlayer.java
+++ b/app/src/main/java/com/dkanada/gramophone/service/playback/LocalPlayer.java
@@ -9,6 +9,8 @@ import com.dkanada.gramophone.R;
 import com.dkanada.gramophone.model.Song;
 import com.dkanada.gramophone.util.MusicUtil;
 import com.dkanada.gramophone.util.PreferenceUtil;
+import com.google.android.exoplayer2.C;
+import com.google.android.exoplayer2.audio.AudioAttributes;
 import com.google.android.exoplayer2.ExoPlaybackException;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.Player.EventListener;
@@ -82,7 +84,12 @@ public class LocalPlayer implements Playback {
         this.context = context;
 
         MediaSourceFactory mediaSourceFactory = new UnknownMediaSourceFactory(buildDataSourceFactory());
-        exoPlayer = new SimpleExoPlayer.Builder(context).setMediaSourceFactory(mediaSourceFactory).build();
+        AudioAttributes audioAttributes = new AudioAttributes.Builder()
+                .setUsage(C.USAGE_MEDIA)
+                .setContentType(C.CONTENT_TYPE_MUSIC)
+                .build();
+
+        exoPlayer = new SimpleExoPlayer.Builder(context).setMediaSourceFactory(mediaSourceFactory).setAudioAttributes(audioAttributes, true).build();
 
         exoPlayer.addListener(eventListener);
         exoPlayer.prepare();

--- a/app/src/main/java/com/dkanada/gramophone/util/PreferenceUtil.java
+++ b/app/src/main/java/com/dkanada/gramophone/util/PreferenceUtil.java
@@ -79,7 +79,6 @@ public final class PreferenceUtil {
     public static final String TRANSCODE_CODEC = "transcode_codec";
     public static final String DIRECT_PLAY_CODECS = "direct_play_codecs";
     public static final String MAXIMUM_BITRATE = "maximum_bitrate";
-    public static final String AUDIO_DUCKING = "audio_ducking";
     public static final String REMEMBER_SHUFFLE = "remember_shuffle";
     public static final String REMEMBER_QUEUE = "remember_queue";
 
@@ -245,10 +244,6 @@ public final class PreferenceUtil {
 
     public final String getMaximumBitrate() {
         return mPreferences.getString(MAXIMUM_BITRATE, "10000000");
-    }
-
-    public final boolean getAudioDucking() {
-        return mPreferences.getBoolean(AUDIO_DUCKING, true);
     }
 
     public final boolean getRememberShuffle() {

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -66,7 +66,6 @@
     <string name="pref_title_blur_album_art">تغييم صورة الألبوم</string>
     <string name="pref_title_colored_notification">إشعار ملون</string>
     <string name="pref_title_classic_notification">تصميم الإشعار الكلاسيكي</string>
-    <string name="pref_title_audio_ducking">خفض الصوت عند فقدان التركيز</string>
     <string name="pref_title_remember_tab">تذكر آخر لسان</string>
     <string name="delete_action">حذف</string>
     <string name="remove_action">إزالة</string>
@@ -90,7 +89,6 @@
     <string name="pref_summary_classic_notification">استعمال تصميم الإشعار الكلاسيكي.</string>
     <string name="pref_summary_colored_notification">"\u062a\u0644\u0648\u064a\u0646 \u0627\u0644\u0625\u0634\u0639\u0627\u0631 \u0628\u0644\u0648\u0646 \u063a\u0644\u0627\u0641 \u0627\u0644\u0623\u0644\u0628\u0648\u0645 \u0627\u0644\u0628\u0627\u0631\u0632."</string>
     <string name="pref_summary_colored_shortcuts">تلوين اختصارات التطبيق باللون الأساسي.</string>
-    <string name="pref_summary_audio_ducking">الإشعارات، التنقل، إلخ.</string>
     <string name="pref_summary_remember_tab">الذهاب إلى آخر لسان مفتوح عند التشغيل</string>
     <string name="last_added">المضافة مؤخراً</string>
     <string name="my_top_tracks">أفضل الأغاني</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -24,7 +24,6 @@
     <string name="songs">الأغاني</string>
     <string name="playlists">قوائم التشغيل</string>
     <string name="unplayable_file">\u0644\u0645 \u064a\u062a\u0645 \u0627\u0644\u062a\u0645\u0643\u0646 \u0645\u0646 \u062a\u0634\u063a\u064a\u0644 \u0627\u0644\u0623\u063a\u0646\u064a\u0629.</string>
-    <string name="audio_focus_denied">تم رفض Audio focus.</string>
     <string name="album">الألبوم</string>
     <string name="label_details">التفاصيل</string>
     <string name="label_file_name">اسم الملف</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -62,7 +62,6 @@
     <string name="pref_title_show_album_art">Покажи обложката на албум</string>
     <string name="pref_title_blur_album_art">Размажи обложката</string>
     <string name="pref_title_colored_notification">Оцвети известията</string>
-    <string name="pref_title_audio_ducking">Намалявай звукът при известия</string>
     <string name="delete_action">Изтрий</string>
     <string name="remove_action">Премахни</string>
     <string name="rename_action">Преименувай</string>
@@ -82,7 +81,6 @@
     <string name="pref_summary_blur_album_art">Замъглява обложката при заключен екран. Би могло да създаде проблеми с апликации и известия създадени от трети лица.</string>
     <string name="pref_summary_colored_notification">"\u041e\u0446\u0432\u0435\u0442\u044f\u0432\u0430 \u0438\u0437\u0432\u0435\u0441\u0442\u0438\u0435\u0442\u043e \u0432 \u0433\u043b\u0430\u0432\u043d\u0438\u044f \u0446\u0432\u044f\u0442 \u043e\u0442 \u043e\u0431\u043b\u043e\u0436\u043a\u0430\u0442\u0430."</string>
     <string name="pref_summary_colored_shortcuts">Оцветява бутоните в главният цвят на апликацията.</string>
-    <string name="pref_summary_audio_ducking">Известия, навигация etc.</string>
     <string name="last_added">Последно добавени</string>
     <string name="my_top_tracks">Моите топ песни</string>
     <string name="action_sleep_timer">Таймер за заспиване</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -23,7 +23,6 @@
     <string name="songs">Песни</string>
     <string name="playlists">Плейлисти</string>
     <string name="unplayable_file">\u0422\u0430\u0437\u0438 \u043f\u0435\u0441\u0435\u043d \u043d\u0435 \u043c\u043e\u0436\u0435 \u0434\u0430 \u0431\u044a\u0434\u0435 \u0432\u044a\u0437\u043f\u0440\u043e\u0438\u0437\u0432\u0435\u0434\u0435\u043d\u0430.</string>
-    <string name="audio_focus_denied">Аудио фокусът бе отказан.</string>
     <string name="album">Албум</string>
     <string name="label_details">Детайли</string>
     <string name="label_file_name">Име на файл</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -24,7 +24,6 @@
     <string name="songs">Skladby</string>
     <string name="playlists">Playlisty</string>
     <string name="unplayable_file">Omlouv\u00e1me se, p\u0159i pokusu p\u0159ehr\u00e1t tuto skladbu do\u0161lo k chyb\u011b</string>
-    <string name="audio_focus_denied">Nebylo možné získat ohnisko zvuku.</string>
     <string name="album">Album</string>
     <string name="label_details">Podrobnosti</string>
     <string name="label_file_name">Název souboru</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -66,7 +66,6 @@
     <string name="pref_title_blur_album_art">Rozostřit obal alba</string>
     <string name="pref_title_colored_notification">Barevné notifikace</string>
     <string name="pref_title_classic_notification">Klasický vzhled oznámení</string>
-    <string name="pref_title_audio_ducking">Snížit hlasitost při ztrátě priority zvuku</string>
     <string name="pref_title_remember_tab">Pamatovat poslední kartu</string>
     <string name="delete_action">Smazat</string>
     <string name="remove_action">Odstranit</string>
@@ -90,7 +89,6 @@
     <string name="pref_summary_classic_notification">Použije klasický vzhled oznámení.</string>
     <string name="pref_summary_colored_notification">"Zbarv\u00ed ozn\u00e1men\u00ed do barev podle obalu alba."</string>
     <string name="pref_summary_colored_shortcuts">Zbarví zkratky aplikace primární barvou</string>
-    <string name="pref_summary_audio_ducking">Oznámení, navigace atd.</string>
     <string name="pref_summary_remember_tab">Přejděte na poslední otevřenou kartu při spuštění</string>
     <string name="last_added">Naposledy přidáno</string>
     <string name="my_top_tracks">"Moje nejposlouchanější skladby "</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -66,7 +66,6 @@
     <string name="pref_title_blur_album_art">Album Cover weichzeichnen</string>
     <string name="pref_title_colored_notification">Gefärbte Benachrichtigung</string>
     <string name="pref_title_classic_notification">Klassisches Benachrichtigungsdesign</string>
-    <string name="pref_title_audio_ducking">Lautstärke bei Fokusverlust verringern</string>
     <string name="pref_title_remember_tab">Letzten Tab merken</string>
     <string name="pref_title_remember_shuffle">Shuffle-Einstellung merken</string>
     <string name="delete_action">Löschen</string>
@@ -93,7 +92,6 @@
     <string name="pref_summary_classic_notification">Das klassische Benachrichtigungsdesign verwenden.</string>
     <string name="pref_summary_colored_notification">"Die Benachrichtigung ist in der Farbe des Album Covers gef\u00e4rbt."</string>
     <string name="pref_summary_colored_shortcuts">Färbt die App-Shortcuts mit der Hauptfarbe.</string>
-    <string name="pref_summary_audio_ducking">Benachrichtigungen, Navigation etc.</string>
     <string name="pref_summary_remember_tab">Zuletzt geöffneten Tab beim Start anzeigen</string>
     <string name="pref_summary_remember_shuffle">Shuffle bleibt aktiviert, wenn neue Songs ausgewählt werden</string>
     <string name="last_added">Zuletzt hinzugefügt</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -24,7 +24,6 @@
     <string name="songs">Titel</string>
     <string name="playlists">Wiedergabelisten</string>
     <string name="unplayable_file">Der Song konnte nicht abgespielt werden.</string>
-    <string name="audio_focus_denied">Kein Audiofokus.</string>
     <string name="album">Album</string>
     <string name="label_details">Details</string>
     <string name="label_file_name">Dateiname</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -24,7 +24,6 @@
     <string name="songs">Τραγούδια</string>
     <string name="playlists">Λίστες αναπαραγωγής</string>
     <string name="unplayable_file">\u03a3\u03c5\u03b3\u03b3\u03bd\u03ce\u03bc\u03b7 - \u03a5\u03c0\u03ae\u03c1\u03be\u03b5 \u03c3\u03c6\u03ac\u03bb\u03bc\u03b1 \u03c3\u03c4\u03b7\u03bd \u03c0\u03c1\u03bf\u03c3\u03c0\u03ac\u03b8\u03b5\u03b9\u03b1 \u03b1\u03bd\u03b1\u03c0\u03b1\u03c1\u03b1\u03b3\u03c9\u03b3\u03ae\u03c2</string>
-    <string name="audio_focus_denied">Έγινε άρνηση εστίασης ήχου</string>
     <string name="album">Άλμπουμ</string>
     <string name="label_details">Λεπτομέρειες</string>
     <string name="label_file_name">Όνομα αρχείου</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -65,7 +65,6 @@
     <string name="pref_title_blur_album_art">Θάμπωμα πορτρέτων καλλιτεχνών</string>
     <string name="pref_title_colored_notification">Χρωματισμένη ειδοποίηση</string>
     <string name="pref_title_classic_notification">Κλασικός σχεδιασμός ειδοποιήσεων</string>
-    <string name="pref_title_audio_ducking">Μειώστε την ένταση στην απώλεια εστίασης</string>
     <string name="delete_action">Διαγραφή</string>
     <string name="remove_action">Αφαίρεση</string>
     <string name="rename_action">Μετονομασία</string>
@@ -85,7 +84,6 @@
     <string name="pref_summary_blur_album_art">Το θωριασμένο album εξώφυλλο στην οθόνη κλειδώματος μπορεί να δημιουργήσει προβλήματα με τρίτες εφαρμογές και συντομιεύσεις.</string>
     <string name="pref_summary_colored_notification">"\u03a7\u03c1\u03c9\u03bc\u03b1\u03c4\u03af\u03b6\u03b5\u03b9 \u03c4\u03b7\u03bd \u03bc\u03c0\u03ac\u03c1\u03b1 \u03b5\u03b9\u03b4\u03bf\u03c0\u03bf\u03b9\u03ae\u03c3\u03b5\u03c9\u03bd \u03c3\u03c4\u03bf \u03c7\u03c1\u03ce\u03bc\u03b1 \u03c4\u03bf\u03c5 album art \u03c4\u03bf\u03c5 \u03c4\u03c1\u03b1\u03b3\u03bf\u03c5\u03b4\u03b9\u03bf\u03cd"</string>
     <string name="pref_summary_colored_shortcuts">Χρωματίζει τις συντομεύσεις της εφαρμογής στο κυρίως χρώμα.</string>
-    <string name="pref_summary_audio_ducking">Ειδοποιήσεις, πλοήγηση κ.λπ.</string>
     <string name="last_added">Προστέθηκαν τελευταία</string>
     <string name="my_top_tracks">Τα κορυφαία κομμάτια μου</string>
     <string name="action_sleep_timer">Χρονοδιακόπτης ύπνου</string>

--- a/app/src/main/res/values-en-rCA/strings.xml
+++ b/app/src/main/res/values-en-rCA/strings.xml
@@ -23,7 +23,6 @@
     <string name="songs">Songs</string>
     <string name="playlists">Playlists</string>
     <string name="unplayable_file">Couldn\u2019t play this song.</string>
-    <string name="audio_focus_denied">Audio focus denied.</string>
     <string name="album">Album</string>
     <string name="label_details">Details</string>
     <string name="label_file_name">File name</string>

--- a/app/src/main/res/values-en-rCA/strings.xml
+++ b/app/src/main/res/values-en-rCA/strings.xml
@@ -64,7 +64,6 @@
     <string name="pref_title_blur_album_art">Blur album cover</string>
     <string name="pref_title_colored_notification">Colored notification</string>
     <string name="pref_title_classic_notification">Classic notification design</string>
-    <string name="pref_title_audio_ducking">Reduce volume on focus loss</string>
     <string name="delete_action">Delete</string>
     <string name="remove_action">Remove</string>
     <string name="rename_action">Rename</string>
@@ -85,7 +84,6 @@
     <string name="pref_summary_classic_notification">Use the classic notification design.</string>
     <string name="pref_summary_colored_notification">"Colors the notification in the album cover\u2019s vibrant color."</string>
     <string name="pref_summary_colored_shortcuts">Colors the app shortcuts in the primary color.</string>
-    <string name="pref_summary_audio_ducking">Notifications, navigation etc.</string>
     <string name="last_added">Last added</string>
     <string name="my_top_tracks">My top tracks</string>
     <string name="action_sleep_timer">Sleep timer</string>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -24,7 +24,6 @@
     <string name="songs">Songs</string>
     <string name="playlists">Playlists</string>
     <string name="unplayable_file">Couldn\'t play this song.</string>
-    <string name="audio_focus_denied">Audio focus denied.</string>
     <string name="album">Album</string>
     <string name="label_details">Details</string>
     <string name="label_file_name">File name</string>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -66,7 +66,6 @@
     <string name="pref_title_blur_album_art">Blur album cover</string>
     <string name="pref_title_colored_notification">Coloured notification</string>
     <string name="pref_title_classic_notification">Classic notification design</string>
-    <string name="pref_title_audio_ducking">Reduce volume on focus loss</string>
     <string name="pref_title_remember_tab">Remember last tab</string>
     <string name="delete_action">Delete</string>
     <string name="remove_action">Remove</string>
@@ -90,7 +89,6 @@
     <string name="pref_summary_classic_notification">Use the classic notification design.</string>
     <string name="pref_summary_colored_notification">"Colours the notification in the album cover\u2019s vibrant colour."</string>
     <string name="pref_summary_colored_shortcuts">Colours the app shortcuts in the primary colour.</string>
-    <string name="pref_summary_audio_ducking">Notifications, navigation etc.</string>
     <string name="pref_summary_remember_tab">Go to the last opened tab on launch</string>
     <string name="last_added">Last added</string>
     <string name="my_top_tracks">My top tracks</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -66,7 +66,6 @@
     <string name="pref_title_blur_album_art">Desenfocar carátula de álbum</string>
     <string name="pref_title_colored_notification">Notificación coloreada</string>
     <string name="pref_title_classic_notification">Diseño clásico de la notificación</string>
-    <string name="pref_title_audio_ducking">Reducir volumen en la pérdida del enfoque</string>
     <string name="pref_title_remember_tab">Recordar la última pestaña</string>
     <string name="pref_title_remember_shuffle">Recordar aleatorio</string>
     <string name="delete_action">Borrar</string>
@@ -91,7 +90,6 @@
     <string name="pref_summary_classic_notification">Utilizar el diseño clásico de notificación.</string>
     <string name="pref_summary_colored_notification">"Colorea la notificaci\u00f3n con el color vibrante de la car\u00e1tula del \u00e1lbum."</string>
     <string name="pref_summary_colored_shortcuts">Colorea los accesos directos con el color principal</string>
-    <string name="pref_summary_audio_ducking">Notificaciones, navegación etc.</string>
     <string name="pref_summary_remember_tab">Ir a la última pestaña abierta en el lanzamiento</string>
     <string name="pref_summary_remember_shuffle">Modo aleatorio estará activado cuando se seleccione una nueva lista de canciones</string>
     <string name="last_added">Último agregado</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -24,7 +24,6 @@
     <string name="songs">Canciones</string>
     <string name="playlists">Listas de reproducción</string>
     <string name="unplayable_file">No es posible reproducir esta canci\u00f3n.</string>
-    <string name="audio_focus_denied">Ajuste de audio denegado.</string>
     <string name="album">Álbum</string>
     <string name="label_details">Detalles</string>
     <string name="label_file_name">Nombre del archivo</string>

--- a/app/src/main/res/values-es-rUS/strings.xml
+++ b/app/src/main/res/values-es-rUS/strings.xml
@@ -24,7 +24,6 @@
     <string name="songs">Canciones</string>
     <string name="playlists">Listas de reproducción</string>
     <string name="unplayable_file">No se ha podido reproducir esta canci\u00f3n.</string>
-    <string name="audio_focus_denied">Enfoque de audio denegado.</string>
     <string name="album">Álbum</string>
     <string name="label_details">Detalles</string>
     <string name="label_file_name">Nombre del archivo</string>

--- a/app/src/main/res/values-es-rUS/strings.xml
+++ b/app/src/main/res/values-es-rUS/strings.xml
@@ -66,7 +66,6 @@
     <string name="pref_title_blur_album_art">Desenfocar imagen de álbum</string>
     <string name="pref_title_colored_notification">Notificación coloreada</string>
     <string name="pref_title_classic_notification">Diseño de notificación clásico</string>
-    <string name="pref_title_audio_ducking">Reducir volumen al recibir notificaciones</string>
     <string name="pref_title_remember_tab">Recordar la última pestaña</string>
     <string name="delete_action">Eliminar</string>
     <string name="remove_action">Eliminar</string>
@@ -90,7 +89,6 @@
     <string name="pref_summary_classic_notification">Usar el diseño de notificación clásico.</string>
     <string name="pref_summary_colored_notification">"Colorea la notificaci\u00f3n con el color vibrante de la car\u00e1tula del \u00e1lbum."</string>
     <string name="pref_summary_colored_shortcuts">Colorea los accesos directos con el color principal.</string>
-    <string name="pref_summary_audio_ducking">Notificaciones, navegación, etc.</string>
     <string name="pref_summary_remember_tab">Ir a la última pestaña abierta al iniciar</string>
     <string name="last_added">Agregadas recientemente</string>
     <string name="my_top_tracks">Más reproducidas</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -24,7 +24,6 @@
     <string name="songs">Kappaleet</string>
     <string name="playlists">Soittolistat</string>
     <string name="unplayable_file">Virhe toistettaessa kappaletta.</string>
-    <string name="audio_focus_denied">Ääntä ei voitu toistaa.</string>
     <string name="album">Albumi</string>
     <string name="label_details">Yksityiskohdat</string>
     <string name="label_file_name">Tiedostonimi</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -67,7 +67,6 @@
     <string name="pref_title_blur_album_art">Sumenna albumin kansi</string>
     <string name="pref_title_colored_notification">Värillinen ilmoitus</string>
     <string name="pref_title_classic_notification">Klassinen ilmoituksen ulkonäkö</string>
-    <string name="pref_title_audio_ducking">Hiljennä ääntä, kun kohdistus menetetään</string>
     <string name="pref_title_remember_tab">Muista viimeisin välilehti</string>
     <string name="pref_title_remember_shuffle">Muista sekoitus</string>
     <string name="delete_action">Poista</string>
@@ -92,7 +91,6 @@
     <string name="pref_summary_classic_notification">Käytä klassista ilmoituksen ulkonäköä.</string>
     <string name="pref_summary_colored_notification">"V\u00e4ritt\u00e4\u00e4 ilmoituksen albumin eloisalla v\u00e4rill\u00e4."</string>
     <string name="pref_summary_colored_shortcuts">Värittää sovelluksen pikavalinnat päävärillä.</string>
-    <string name="pref_summary_audio_ducking">Ilmoitukset, liikkuminen jne.</string>
     <string name="pref_summary_remember_tab">Palauttaa käynnistyessään viimeksi avoinna olleen välilehden.</string>
     <string name="pref_summary_remember_shuffle">Sekoitus-tila pysyy päällä, kun valitset uuden listan kappaleita</string>
     <string name="last_added">Viimeksi lisätyt</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -66,7 +66,6 @@
     <string name="pref_title_blur_album_art">Flouter la pochette d\'album</string>
     <string name="pref_title_colored_notification">Notification colorée</string>
     <string name="pref_title_classic_notification">Style de notification classique</string>
-    <string name="pref_title_audio_ducking">Réduction du volume</string>
     <string name="pref_title_remember_tab">Se souvenir de la dernière fenêtre</string>
     <string name="delete_action">Supprimer</string>
     <string name="remove_action">Retirer</string>
@@ -90,7 +89,6 @@
     <string name="pref_summary_classic_notification">Utiliser le style de notification classique.</string>
     <string name="pref_summary_colored_notification">"Colore la notification en fonction de la pochette de l'album."</string>
     <string name="pref_summary_colored_shortcuts">Colore les raccourcis de l\'application selon la couleur primaire.</string>
-    <string name="pref_summary_audio_ducking">Réduire le volume pour les notifications et autre sons système.</string>
     <string name="pref_summary_remember_tab">Aller à la dernière catégorie ouverte lors du lancement.</string>
     <string name="last_added">Derniers ajouts</string>
     <string name="my_top_tracks">Mes meilleurs titres</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -24,7 +24,6 @@
     <string name="songs">Titres</string>
     <string name="playlists">Playlists</string>
     <string name="unplayable_file">Impossible de lire ce titre.</string>
-    <string name="audio_focus_denied">Accès à l\'Audio Focus refusé.</string>
     <string name="album">Album</string>
     <string name="label_details">Détails</string>
     <string name="label_file_name">Nom du fichier</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -24,7 +24,6 @@
     <string name="songs">שירים</string>
     <string name="playlists">רשימות השמעה</string>
     <string name="unplayable_file">\u05dc\u05d0 \u05e0\u05d9\u05ea\u05df \u05dc\u05e0\u05d2\u05df \u05e9\u05d9\u05e8 \u05d6\u05d4.</string>
-    <string name="audio_focus_denied">מיקוד שמע נדחה.</string>
     <string name="album">אלבום</string>
     <string name="label_details">פרטים</string>
     <string name="label_file_name">שם הקובץ</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -66,7 +66,6 @@
     <string name="pref_title_blur_album_art">טשטוש עטיפת האלבום</string>
     <string name="pref_title_colored_notification">התראה צבעונית</string>
     <string name="pref_title_classic_notification">עיצוב התראה קלאיסי</string>
-    <string name="pref_title_audio_ducking">הפחת את עוצמת הקול באובדן מיקוד</string>
     <string name="pref_title_remember_tab">זכור את הכרטיסיה האחרונה</string>
     <string name="delete_action">מחיקה</string>
     <string name="remove_action">הסרה</string>
@@ -90,7 +89,6 @@
     <string name="pref_summary_classic_notification">השתמש בעיצוב התראות קלאסי.</string>
     <string name="pref_summary_colored_notification">"\u05e6\u05d5\u05d1\u05e2 \u05d0\u05ea \u05d4\u05ea\u05e8\u05d0\u05ea \u05d4\u05e0\u05d2\u05df \u05d1\u05e6\u05d1\u05e2 \u05d4\u05de\u05e8\u05db\u05d6\u05d9 \u05e9\u05dc \u05ea\u05de\u05d5\u05e0\u05ea \u05d4\u05d0\u05dc\u05d1\u05d5\u05dd."</string>
     <string name="pref_summary_colored_shortcuts">צובע את קיצורי האפליקציה בצבע הראשי.</string>
-    <string name="pref_summary_audio_ducking">התראות, ניווט וכו\'</string>
     <string name="pref_summary_remember_tab">עבור לכרטיסייה האחרונה שהייתה פתוחה בהפעלה</string>
     <string name="last_added">נוספו לאחרונה</string>
     <string name="my_top_tracks">השירים המובילים שלי</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -24,7 +24,6 @@
     <string name="songs">Pjesme</string>
     <string name="playlists">Popisi naslova</string>
     <string name="unplayable_file">Nije mogu\u0107e reproducirati ovu pjesmu.</string>
-    <string name="audio_focus_denied">Zvučni fokus je odbijen.</string>
     <string name="album">Album</string>
     <string name="label_details">Detalji</string>
     <string name="label_file_name">Naziv datoteke</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -66,7 +66,6 @@
     <string name="pref_title_blur_album_art">Zamagli omot albuma</string>
     <string name="pref_title_colored_notification">Obojene obavijesti</string>
     <string name="pref_title_classic_notification">Klasični dizajn obavijesti</string>
-    <string name="pref_title_audio_ducking">Smanji glasn. prilikom drugih zvukova</string>
     <string name="pref_title_remember_tab">Zapamti zadnju karticu</string>
     <string name="delete_action">Izbriši</string>
     <string name="remove_action">Ukloni</string>
@@ -90,7 +89,6 @@
     <string name="pref_summary_classic_notification">Koristi klasični dizajn obavijesti.</string>
     <string name="pref_summary_colored_notification">"Obavijesti su obojene istaknutom bojom omota albuma."</string>
     <string name="pref_summary_colored_shortcuts">Boja prečace aplikacije u primarnu boju.</string>
-    <string name="pref_summary_audio_ducking">Obavijesti, navigacija itd.</string>
     <string name="pref_summary_remember_tab">Pri pokretanju otvori zadnje otvorenu karticu</string>
     <string name="last_added">Posljednje dodano</string>
     <string name="my_top_tracks">Najslušanije</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -24,7 +24,6 @@
     <string name="songs">Dalok</string>
     <string name="playlists">Lejátszási listák</string>
     <string name="unplayable_file">Nem lehet lej\u00e1tszani ezt a dalt.</string>
-    <string name="audio_focus_denied">Audiofókusz megtagadva.</string>
     <string name="album">Album</string>
     <string name="label_details">Részletek</string>
     <string name="label_file_name">Fájlnév</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -66,7 +66,6 @@
     <string name="pref_title_blur_album_art">Albumborító elhomályosítása</string>
     <string name="pref_title_colored_notification">Színezett értesítés</string>
     <string name="pref_title_classic_notification">Klasszikus értesítési dízájn</string>
-    <string name="pref_title_audio_ducking">Hangerő csökkentése</string>
     <string name="pref_title_remember_tab">Emlékezz az utolsó fülre</string>
     <string name="delete_action">Törlés</string>
     <string name="remove_action">Eltávolítás</string>
@@ -90,7 +89,6 @@
     <string name="pref_summary_classic_notification">Használja a klasszikus értesítési dizájn.</string>
     <string name="pref_summary_colored_notification">"\u00c9rtes\u00edt\u00e9sek sz\u00ednez\u00e9se az albumbor\u00edt\u00f3 sz\u00edn\u00e9vel."</string>
     <string name="pref_summary_colored_shortcuts">Az alkalmazás hivatkozások színezése az elsődleges szín szerint.</string>
-    <string name="pref_summary_audio_ducking">Beérkező értesítéskor a lejátszás hangereje lecsökken, majd az értesítés végén visszaáll az eredeti hangerőre.</string>
     <string name="pref_summary_remember_tab">Menjen az utolsó megnyitott fülre az indításkor</string>
     <string name="last_added">Legfrissebb dalok</string>
     <string name="my_top_tracks">Toplista</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -24,7 +24,6 @@
     <string name="songs">Lagu</string>
     <string name="playlists">Daftar putar</string>
     <string name="unplayable_file">Tidak dapat memutar lagu ini.</string>
-    <string name="audio_focus_denied">Fokus audio ditolak.</string>
     <string name="album">Album</string>
     <string name="label_details">Rincian</string>
     <string name="label_file_name">Nama berkas</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -67,7 +67,6 @@
     <string name="pref_title_blur_album_art">Buramkan sampul album</string>
     <string name="pref_title_colored_notification">Notifikasi berwarna</string>
     <string name="pref_title_classic_notification">Desain notifikasi klasik</string>
-    <string name="pref_title_audio_ducking">Kurangi suara saat ada pemberitahuan</string>
     <string name="pref_title_remember_tab">Ingat tab terakhir</string>
     <string name="pref_title_remember_shuffle">Ingat putar acak</string>
     <string name="delete_action">Hapus</string>
@@ -92,7 +91,6 @@
     <string name="pref_summary_classic_notification">Gunakan desain notifikasi klasik.</string>
     <string name="pref_summary_colored_notification">"Mewarnai notifikasi putar dengan warna yang cerah dari album."</string>
     <string name="pref_summary_colored_shortcuts">Mewarnai pintasan-pintasan dengan warna utama.</string>
-    <string name="pref_summary_audio_ducking">Pemberitahuan, navigasi dll.</string>
     <string name="pref_summary_remember_tab">Pergi ke tab yang terakhir saat aplikasi dibuka</string>
     <string name="pref_summary_remember_shuffle">Mode putar acak akan tetap aktif saat memilih daftar lagu baru</string>
     <string name="last_added">Terakhir ditambahkan</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -24,7 +24,6 @@
     <string name="songs">Lagu</string>
     <string name="playlists">Daftar putar</string>
     <string name="unplayable_file">Tidak dapat memutar lagu ini.</string>
-    <string name="audio_focus_denied">Fokus audio ditolak.</string>
     <string name="album">Album</string>
     <string name="label_details">Rincian</string>
     <string name="label_file_name">Nama berkas</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -67,7 +67,6 @@
     <string name="pref_title_blur_album_art">Buramkan sampul album</string>
     <string name="pref_title_colored_notification">Notifikasi berwarna</string>
     <string name="pref_title_classic_notification">Desain notifikasi klasik</string>
-    <string name="pref_title_audio_ducking">Kurangi suara saat ada pemberitahuan</string>
     <string name="pref_title_remember_tab">Ingat tab terakhir</string>
     <string name="pref_title_remember_shuffle">Ingat putar acak</string>
     <string name="delete_action">Hapus</string>
@@ -92,7 +91,6 @@
     <string name="pref_summary_classic_notification">Gunakan desain notifikasi klasik.</string>
     <string name="pref_summary_colored_notification">"Mewarnai notifikasi putar dengan warna yang cerah dari album."</string>
     <string name="pref_summary_colored_shortcuts">Mewarnai pintasan-pintasan dengan warna utama.</string>
-    <string name="pref_summary_audio_ducking">Pemberitahuan, navigasi dll.</string>
     <string name="pref_summary_remember_tab">Pergi ke tab yang terakhir saat aplikasi dibuka</string>
     <string name="pref_summary_remember_shuffle">Mode putar acak akan tetap aktif saat memilih daftar lagu baru</string>
     <string name="last_added">Terakhir ditambahkan</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -24,7 +24,6 @@
     <string name="songs">Brani</string>
     <string name="playlists">Playlist</string>
     <string name="unplayable_file">Impossibile riprodurre questo brano.</string>
-    <string name="audio_focus_denied">Focus audio negato.</string>
     <string name="album">Album</string>
     <string name="label_details">Dettagli</string>
     <string name="label_file_name">Nome file</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -67,7 +67,6 @@
     <string name="pref_title_blur_album_art">Sfoca la copertina</string>
     <string name="pref_title_colored_notification">Notifica colorata</string>
     <string name="pref_title_classic_notification">Design di notifica classico</string>
-    <string name="pref_title_audio_ducking">Riduci volume in caso di perdita di focus audio</string>
     <string name="pref_title_remember_tab">Ricorda ultima scheda</string>
     <string name="pref_title_remember_shuffle">Ricorda casuale</string>
     <string name="delete_action">Elimina</string>
@@ -92,7 +91,6 @@
     <string name="pref_summary_classic_notification">Usa il design di notifica classico.</string>
     <string name="pref_summary_colored_notification">"La notifica \u00e8 colorata secondo la gamma di colori della copertina."</string>
     <string name="pref_summary_colored_shortcuts">Colora le scorciatoie dell\'app con il colore principale.</string>
-    <string name="pref_summary_audio_ducking">Notifiche, navigazione ecc.</string>
     <string name="pref_summary_remember_tab">All\'avvio vai all\'ultima scheda aperta</string>
     <string name="pref_summary_remember_shuffle">La modalità casuale rimarrà attiva quando si seleziona un nuovo elenco di brani</string>
     <string name="last_added">Aggiunti di recente</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -24,7 +24,6 @@
     <string name="songs">שירים</string>
     <string name="playlists">רשימות השמעה</string>
     <string name="unplayable_file">\u05dc\u05d0 \u05e0\u05d9\u05ea\u05df \u05dc\u05e0\u05d2\u05df \u05e9\u05d9\u05e8 \u05d6\u05d4.</string>
-    <string name="audio_focus_denied">מיקוד שמע נדחה.</string>
     <string name="album">אלבום</string>
     <string name="label_details">פרטים</string>
     <string name="label_file_name">שם הקובץ</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -66,7 +66,6 @@
     <string name="pref_title_blur_album_art">טשטוש עטיפת האלבום</string>
     <string name="pref_title_colored_notification">התראה צבעונית</string>
     <string name="pref_title_classic_notification">עיצוב התראה קלאיסי</string>
-    <string name="pref_title_audio_ducking">הפחת את עוצמת הקול באובדן מיקוד</string>
     <string name="pref_title_remember_tab">זכור את הכרטיסיה האחרונה</string>
     <string name="delete_action">מחיקה</string>
     <string name="remove_action">הסרה</string>
@@ -90,7 +89,6 @@
     <string name="pref_summary_classic_notification">השתמש בעיצוב התראות קלאסי.</string>
     <string name="pref_summary_colored_notification">"\u05e6\u05d5\u05d1\u05e2 \u05d0\u05ea \u05d4\u05ea\u05e8\u05d0\u05ea \u05d4\u05e0\u05d2\u05df \u05d1\u05e6\u05d1\u05e2 \u05d4\u05de\u05e8\u05db\u05d6\u05d9 \u05e9\u05dc \u05ea\u05de\u05d5\u05e0\u05ea \u05d4\u05d0\u05dc\u05d1\u05d5\u05dd."</string>
     <string name="pref_summary_colored_shortcuts">צובע את קיצורי האפליקציה בצבע הראשי.</string>
-    <string name="pref_summary_audio_ducking">התראות, ניווט וכו\'</string>
     <string name="pref_summary_remember_tab">עבור לכרטיסייה האחרונה שהייתה פתוחה בהפעלה</string>
     <string name="last_added">נוספו לאחרונה</string>
     <string name="my_top_tracks">השירים המובילים שלי</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -66,7 +66,6 @@
     <string name="pref_title_blur_album_art">アルバムアートにぼかし効果をかける</string>
     <string name="pref_title_colored_notification">通知に色を付ける</string>
     <string name="pref_title_classic_notification">古い通知デザイン</string>
-    <string name="pref_title_audio_ducking">音声フォーカス喪失時に音量を下げる</string>
     <string name="pref_title_remember_tab">最後のタブの記憶</string>
     <string name="delete_action">削除</string>
     <string name="remove_action">除去</string>
@@ -90,7 +89,6 @@
     <string name="pref_summary_classic_notification">旧式の通知デザインを使用します。</string>
     <string name="pref_summary_colored_notification">"\u901a\u77e5\u306e\u8272\u3092\u30a2\u30eb\u30d0\u30e0\u30a2\u30fc\u30c8\u304b\u3089\u62bd\u51fa\u3057\u305f\u8272\u306b\u5909\u66f4\u3057\u307e\u3059\u3002"</string>
     <string name="pref_summary_colored_shortcuts">アプリのショートカットの色をメインカラーに変更します。</string>
-    <string name="pref_summary_audio_ducking">通知やナビなどです。</string>
     <string name="pref_summary_remember_tab">アプリ起動時に最後に開いていたタブを開く</string>
     <string name="last_added">最近追加された曲</string>
     <string name="my_top_tracks">よく聞く曲</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -24,7 +24,6 @@
     <string name="songs">曲</string>
     <string name="playlists">プレイリスト</string>
     <string name="unplayable_file">\u697d\u66f2\u306e\u518d\u751f\u6642\u306b\u30a8\u30e9\u30fc\u304c\u767a\u751f\u3057\u307e\u3057\u305f</string>
-    <string name="audio_focus_denied">オーディオフォーカスが禁止されています</string>
     <string name="album">アルバム</string>
     <string name="label_details">詳細情報</string>
     <string name="label_file_name">ファイル名</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -24,7 +24,6 @@
     <string name="songs">노래</string>
     <string name="playlists">재생 목록</string>
     <string name="unplayable_file">\uc74c\uc545 \ud30c\uc77c \uc624\ub958\ub85c \uc7ac\uc0dd\ud560 \uc218 \uc5c6\uc2b5\ub2c8\ub2e4.</string>
-    <string name="audio_focus_denied">오디오 포커스 권한이 거부되었습니다.</string>
     <string name="album">앨범</string>
     <string name="label_details">세부 정보</string>
     <string name="label_file_name">파일 이름</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -66,7 +66,6 @@
     <string name="pref_title_blur_album_art">앨범 커버 블러 효과</string>
     <string name="pref_title_colored_notification">알림 색상 틴트</string>
     <string name="pref_title_classic_notification">클래식 알림 디자인</string>
-    <string name="pref_title_audio_ducking">포커스 상실 시 볼륨 감소하기</string>
     <string name="pref_title_remember_tab">마지막 탭 기억</string>
     <string name="delete_action">삭제</string>
     <string name="remove_action">제거</string>
@@ -90,7 +89,6 @@
     <string name="pref_summary_classic_notification">클래식 알림 디자인 사용</string>
     <string name="pref_summary_colored_notification">"\uc54c\ub9bc \ucee8\ud2b8\ub864\uc744 \uc568\ubc94 \uc544\ud2b8\uc758 \uc8fc \uc0c9\uc0c1\uc73c\ub85c \uce60\ud569\ub2c8\ub2e4."</string>
     <string name="pref_summary_colored_shortcuts">주 색상으로 앱 바로가기 색칠</string>
-    <string name="pref_summary_audio_ducking">알림 소리, 버튼음 등</string>
     <string name="pref_summary_remember_tab">마지막으로 연 탭으로 시작</string>
     <string name="last_added">최근 추가됨</string>
     <string name="my_top_tracks">많이 재생한 트랙</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -24,7 +24,6 @@
     <string name="songs">Nummers</string>
     <string name="playlists">Afspeellijsten</string>
     <string name="unplayable_file">Kan dit nummer niet afspelen.</string>
-    <string name="audio_focus_denied">Audiofocus geweigerd.</string>
     <string name="album">Album</string>
     <string name="label_details">Details</string>
     <string name="label_file_name">Bestandsnaam</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -66,7 +66,6 @@
     <string name="pref_title_blur_album_art">Vervaag albumhoes</string>
     <string name="pref_title_colored_notification">Gekleurde melding</string>
     <string name="pref_title_classic_notification">Klassieke meldingsweergave</string>
-    <string name="pref_title_audio_ducking">Verminder volume bij focusverlies</string>
     <string name="pref_title_remember_tab">Laatste tabblad onthouden</string>
     <string name="delete_action">Verwijderen</string>
     <string name="remove_action">Verwijderen</string>
@@ -90,7 +89,6 @@
     <string name="pref_summary_classic_notification">Gebruik de klassieke meldingsweergave.</string>
     <string name="pref_summary_colored_notification">"Kleurt de melding met het palet van de albumhoes."</string>
     <string name="pref_summary_colored_shortcuts">Kleurt de app-snelkoppelingen in de primaire kleur.</string>
-    <string name="pref_summary_audio_ducking">Notificaties, navigatie, etc.</string>
     <string name="pref_summary_remember_tab">Ga naar het laatst geopende tabblad bij opstarten</string>
     <string name="last_added">Laatst toegevoegd</string>
     <string name="my_top_tracks">Mijn top nummers</string>

--- a/app/src/main/res/values-nn/strings.xml
+++ b/app/src/main/res/values-nn/strings.xml
@@ -10,7 +10,6 @@
     <string name="songs">Songar</string>
     <string name="playlists">Spelelister</string>
     <string name="unplayable_file">Orsak - ein feil oppstod medan spelaren pr\u00f8vde \u00e5 spele denne songen</string>
-    <string name="audio_focus_denied">We were not able to gain audio focus.</string>
     <string name="album">Album</string>
     <string name="label_details">Detaljar</string>
     <string name="label_file_name">Filnamn</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -24,7 +24,6 @@
     <string name="songs">Utwory</string>
     <string name="playlists">Listy odtwarzania</string>
     <string name="unplayable_file">Utw\u00f3r nie mo\u017ce zosta\u0107 odegrany</string>
-    <string name="audio_focus_denied">Nie można teraz odtworzyć dźwięku</string>
     <string name="album">Album</string>
     <string name="label_details">Szczegóły</string>
     <string name="label_file_name">Nazwa pliku</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -66,7 +66,6 @@
     <string name="pref_title_blur_album_art">Rozmywanie okładki albumu</string>
     <string name="pref_title_colored_notification">Kolorowy odtwarzacz w pasku powiadomień</string>
     <string name="pref_title_classic_notification">Klasyczny wygląd powiadomienia</string>
-    <string name="pref_title_audio_ducking">Zmniejszaj głośność przy powiadomieniach</string>
     <string name="pref_title_remember_tab">"Zapamiętaj ostatnią zakładkę "</string>
     <string name="delete_action">Usuń</string>
     <string name="remove_action">Usuń</string>
@@ -90,7 +89,6 @@
     <string name="pref_summary_classic_notification">Używaj klasycznego stylu powiadomienia.</string>
     <string name="pref_summary_colored_notification">"Odtwarzacz w pasku powiadomie\u0144 ma tonacj\u0119 ok\u0142adki albumu"</string>
     <string name="pref_summary_colored_shortcuts">Kolory skrótów aplikacji w kolorze podstawowym</string>
-    <string name="pref_summary_audio_ducking">Notyfikacje, nawigacja, itp.</string>
     <string name="pref_summary_remember_tab">Idź do ostatniej otwartej zakładki przy starcie</string>
     <string name="last_added">Ostatnio dodane</string>
     <string name="my_top_tracks">Moja Top Lista</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -67,7 +67,6 @@
     <string name="pref_title_blur_album_art">Capa de álbum esmaecida</string>
     <string name="pref_title_colored_notification">Notificação colorida</string>
     <string name="pref_title_classic_notification">Design de classificação clássico</string>
-    <string name="pref_title_audio_ducking">Reduzir o volume de perda de foco</string>
     <string name="pref_title_remember_tab">Lembrar última aba</string>
     <string name="pref_title_remember_shuffle">Memorizar aleatorização</string>
     <string name="delete_action">Excluir</string>
@@ -92,7 +91,6 @@
     <string name="pref_summary_classic_notification">Usar o design de notificação clássico.</string>
     <string name="pref_summary_colored_notification">"A notifica\u00e7\u00e3o \u00e9 colorida com a cor mais vibrante do \u00e1lbum."</string>
     <string name="pref_summary_colored_shortcuts">Colore os atalhos do app com a cor primária.</string>
-    <string name="pref_summary_audio_ducking">Notificações, navegação, etc.</string>
     <string name="pref_summary_remember_tab">Ir para a última aba aberta ao iniciar</string>
     <string name="pref_summary_remember_shuffle">Modo aleatório continuará ativo quando uma nova lista de músicas for selecionada</string>
     <string name="last_added">Última Adição</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -24,7 +24,6 @@
     <string name="songs">Músicas</string>
     <string name="playlists">Listas de Reprodução</string>
     <string name="unplayable_file">N\u00e3o foi poss\u00edvel reproduzir esta m\u00fasica.</string>
-    <string name="audio_focus_denied">Foco do áudio negado.</string>
     <string name="album">Álbum</string>
     <string name="label_details">Detalhes</string>
     <string name="label_file_name">Nome do arquivo</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -20,7 +20,6 @@
     <string name="songs">Músicas</string>
     <string name="playlists">Listas de reprodução</string>
     <string name="unplayable_file">Ocorreu um erro ao tentar reproduzir esta faixa.</string>
-    <string name="audio_focus_denied">Foco de áudio negado.</string>
     <string name="album">Álbum</string>
     <string name="label_details">Detalhes</string>
     <string name="label_file_name">Nome do ficheiro</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -76,7 +76,6 @@
     <string name="pref_summary_show_album_art">Usa a capa de álbum da faixa atual como papel de parede da tela de bloqueio.</string>
     <string name="pref_summary_blur_album_art">Desfoca a capa do álbum no ecrã de bloqueio. Pode causar problemas com aplicações de terceiros e widgets.</string>
     <string name="pref_summary_colored_notification">"Colorir a notifica\u00e7\u00e3o na cor viva da capa de \u00e1lbum."</string>
-    <string name="pref_summary_audio_ducking">Notificações, navegação etc.</string>
     <string name="last_added">Últimas adições</string>
     <string name="my_top_tracks">As minhas faixas favoritas</string>
     <string name="action_sleep_timer">Temporizador para dormir</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -24,7 +24,6 @@
     <string name="songs">Melodii</string>
     <string name="playlists">Liste de redare</string>
     <string name="unplayable_file">Nu se poate reda.</string>
-    <string name="audio_focus_denied">Focus audio respins.</string>
     <string name="album">Album</string>
     <string name="label_details">Detalii</string>
     <string name="label_file_name">Nume fișier</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -66,7 +66,6 @@
     <string name="pref_title_blur_album_art">Blurează coperta de album</string>
     <string name="pref_title_colored_notification">Notificare colorată</string>
     <string name="pref_title_classic_notification">Design clasic de notificare</string>
-    <string name="pref_title_audio_ducking">Se reduce volumul la pierderea focalizării</string>
     <string name="pref_title_remember_tab">Rețineți ultima filă</string>
     <string name="delete_action">Șterge</string>
     <string name="remove_action">Ștergeți</string>
@@ -90,7 +89,6 @@
     <string name="pref_summary_classic_notification">Utilizați designul clasic de notificare.</string>
     <string name="pref_summary_colored_notification">"Coloreaz\u0103 bara de notificare cu cea mai vibrant\u0103 culoare a copertei de album."</string>
     <string name="pref_summary_colored_shortcuts">Colorarea comenzilor rapide ale aplicației în culoarea primară.</string>
-    <string name="pref_summary_audio_ducking">Notificări, navigație etc.</string>
     <string name="pref_summary_remember_tab">Accesați ultima filă deschisă la lansare</string>
     <string name="last_added">Ultimele adăugate</string>
     <string name="my_top_tracks">Melodiile mele favorite</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -24,7 +24,6 @@
     <string name="songs">Треки</string>
     <string name="playlists">Плейлисты</string>
     <string name="unplayable_file">\u041d\u0435 \u0443\u0434\u0430\u043b\u043e\u0441\u044c \u0432\u043e\u0441\u043f\u0440\u043e\u0438\u0437\u0432\u0435\u0441\u0442\u0438 \u044d\u0442\u0443 \u043f\u0435\u0441\u043d\u044e.</string>
-    <string name="audio_focus_denied">В получении аудиофокуса отказано.</string>
     <string name="album">Альбом</string>
     <string name="label_details">Подробнее</string>
     <string name="label_file_name">Имя файла</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -67,7 +67,6 @@
     <string name="pref_title_blur_album_art">Размытая обложка альбома</string>
     <string name="pref_title_colored_notification">Окрашенное уведомление</string>
     <string name="pref_title_classic_notification">Стандартный дизайн уведомления</string>
-    <string name="pref_title_audio_ducking">Уменьшить громкость при уведомлениях</string>
     <string name="pref_title_remember_tab">Запомнить последнюю вкладку</string>
     <string name="pref_title_remember_shuffle">Запомнить перемешивание</string>
     <string name="delete_action">Удалить</string>
@@ -92,7 +91,6 @@
     <string name="pref_summary_classic_notification">Использовать классический дизайн уведомления.</string>
     <string name="pref_summary_colored_notification">"\u041e\u043a\u0440\u0430\u0448\u0438\u0432\u0430\u0435\u0442 \u0443\u0432\u0435\u0434\u043e\u043c\u043b\u0435\u043d\u0438\u0435 \u0432 \u0442\u043e\u043d \u043e\u0431\u043b\u043e\u0436\u043a\u0438 \u0430\u043b\u044c\u0431\u043e\u043c\u0430."</string>
     <string name="pref_summary_colored_shortcuts">Окрашивает шорткаты в основной цвет.</string>
-    <string name="pref_summary_audio_ducking">Уведомления, навигация, т.д.</string>
     <string name="pref_summary_remember_tab">Перейти на последнюю открытую вкладку при запуске</string>
     <string name="pref_summary_remember_shuffle">Режим перемешивания останется включенным при выборе нового списка песен</string>
     <string name="last_added">Последние добавленные</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -20,7 +20,6 @@
     <string name="songs">Låtar</string>
     <string name="playlists">Spellistor</string>
     <string name="unplayable_file">Ett problem uppstod vid spelningen av denna l\u00e5t.</string>
-    <string name="audio_focus_denied">Kunde inte hitta ljudfokus</string>
     <string name="album">Album</string>
     <string name="label_details">Detaljer</string>
     <string name="label_file_name">Filnamn</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -66,7 +66,6 @@
     <string name="pref_title_blur_album_art">Bulanık albüm kapağı</string>
     <string name="pref_title_colored_notification">Renkli bildirim</string>
     <string name="pref_title_classic_notification">Klasik bildirim tasarımı</string>
-    <string name="pref_title_audio_ducking">Odak kaybına neden olacak sesi azalt</string>
     <string name="pref_title_remember_tab">Son sekmeyi hatırla</string>
     <string name="delete_action">Sil</string>
     <string name="remove_action">Kaldır</string>
@@ -90,7 +89,6 @@
     <string name="pref_summary_classic_notification">Klasik bildirim tasarımını kullan.</string>
     <string name="pref_summary_colored_notification">"Bildirimler alb\u00fcm kapa\u011f\u0131n\u0131n canl\u0131 renkleriyle renklendirilir."</string>
     <string name="pref_summary_colored_shortcuts">Uygulama kısayollarını ana renk ile renklendir.</string>
-    <string name="pref_summary_audio_ducking">Bildirimler, gezinme vb.</string>
     <string name="pref_summary_remember_tab">Başlatıldığında son açılan sekmeye git</string>
     <string name="last_added">Son eklenen</string>
     <string name="my_top_tracks">En iyi parçalarım</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -24,7 +24,6 @@
     <string name="songs">Şarkılar</string>
     <string name="playlists">Çalma listeleri</string>
     <string name="unplayable_file">Bu \u015fark\u0131 \u00e7al\u0131namad\u0131.</string>
-    <string name="audio_focus_denied">Ses odağı reddedildi.</string>
     <string name="album">Albüm</string>
     <string name="label_details">Ayrıntılar</string>
     <string name="label_file_name">Dosya adı</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -24,7 +24,6 @@
     <string name="songs">Пісні</string>
     <string name="playlists">Списки відтворення</string>
     <string name="unplayable_file">\u041d\u0435 \u0432\u0434\u0430\u043b\u043e\u0441\u044f \u0432\u0456\u0434\u0442\u0432\u043e\u0440\u0438\u0442\u0438 \u043f\u0456\u0441\u043d\u044e.</string>
-    <string name="audio_focus_denied">В отриманні аудіофокусу відмовлено.</string>
     <string name="album">Альбом</string>
     <string name="label_details">Подробиці</string>
     <string name="label_file_name">Назва файлу</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -66,7 +66,6 @@
     <string name="pref_title_blur_album_art">Розмити обкладинку альбому</string>
     <string name="pref_title_colored_notification">Кольорове сповіщення</string>
     <string name="pref_title_classic_notification">Класичне оформлення сповіщення</string>
-    <string name="pref_title_audio_ducking">Зменшити гучнiсть при отриманнi повiдомлення</string>
     <string name="pref_title_remember_tab">Запам‘ятати останню вкладку</string>
     <string name="delete_action">Видалити</string>
     <string name="remove_action">Видалити</string>
@@ -90,7 +89,6 @@
     <string name="pref_summary_classic_notification">Використовувати класичне оформлення сповіщення.</string>
     <string name="pref_summary_colored_notification">"\u0424\u0430\u0440\u0431\u0443\u0454 \u043f\u043e\u0432\u0456\u0434\u043e\u043c\u043b\u0435\u043d\u043d\u044f \u0432 \u043f\u0435\u0440\u0435\u0432\u0430\u0436\u043d\u0438\u0439 \u043a\u043e\u043b\u0456\u0440 \u043e\u0431\u043a\u043b\u0430\u0434\u0438\u043d\u043a\u0438 \u0430\u043b\u044c\u0431\u043e\u043c\u0443."</string>
     <string name="pref_summary_colored_shortcuts">Фарбує ярлики додатків у переважний колір.</string>
-    <string name="pref_summary_audio_ducking">Повiдомлення, навiгацiя, т.д.</string>
     <string name="pref_summary_remember_tab">Перейдіть до останньої відкритої вкладки, щоб запустити</string>
     <string name="last_added">Останні додані</string>
     <string name="my_top_tracks">Мої популярні треки</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -64,7 +64,6 @@
     <string name="pref_title_blur_album_art">Làm mờ bìa album</string>
     <string name="pref_title_colored_notification">Màu thông báo</string>
     <string name="pref_title_classic_notification">Thiết kế thông báo cổ điển</string>
-    <string name="pref_title_audio_ducking">Giảm âm lượng khi mất tập trung</string>
     <string name="delete_action">Xóa</string>
     <string name="remove_action">Di chuyển</string>
     <string name="rename_action">Đổi tên</string>
@@ -85,7 +84,6 @@
     <string name="pref_summary_classic_notification">Sử dụng thiết kế thông báo cổ điển.</string>
     <string name="pref_summary_colored_notification">"M\u00e0u s\u1eafc r\u1ef1c r\u1ee1 cho c\u00e1c th\u00f4ng b\u00e1o trong b\u00eca album."</string>
     <string name="pref_summary_colored_shortcuts">Màu sắc chủ đạo của biểu tượng ứng dụng.</string>
-    <string name="pref_summary_audio_ducking">Thông báo, điều hướng, vv.</string>
     <string name="last_added">Được thêm sau cùng</string>
     <string name="my_top_tracks">Bài hát hàng đầu</string>
     <string name="action_sleep_timer">Hẹn giờ ngủ</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -23,7 +23,6 @@
     <string name="songs">Bài hát</string>
     <string name="playlists">Danh sách nhạc</string>
     <string name="unplayable_file">Kh\u00f4ng th\u1ec3 ph\u00e1t b\u00e0i h\u00e1t n\u00e0y.</string>
-    <string name="audio_focus_denied">Âm thanh trọng tâm bị từ chối.</string>
     <string name="album">Album</string>
     <string name="label_details">Chi tiết</string>
     <string name="label_file_name">Tên tập tin</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -67,7 +67,6 @@
     <string name="pref_title_blur_album_art">专辑封面模糊化</string>
     <string name="pref_title_colored_notification">启用通知背景着色</string>
     <string name="pref_title_classic_notification">经典通知样式</string>
-    <string name="pref_title_audio_ducking">音频焦点丢失时降低音量</string>
     <string name="pref_title_remember_tab">记住最后打开页面</string>
     <string name="delete_action">删除</string>
     <string name="remove_action">移除</string>
@@ -91,7 +90,6 @@
     <string name="pref_summary_classic_notification">使用经典通知样式。</string>
     <string name="pref_summary_colored_notification">"\u4f7f\u7528\u4e0e\u4e13\u8f91\u5c01\u9762\u76f8\u5339\u914d\u7684\u989c\u8272\u7740\u8272\u901a\u77e5\u80cc\u666f\u8272\u3002"</string>
     <string name="pref_summary_colored_shortcuts">用主色调着色应用快捷方式。</string>
-    <string name="pref_summary_audio_ducking">通知、导航等</string>
     <string name="pref_summary_remember_tab">启动时跳转到最后打开页面</string>
     <string name="last_added">最近添加</string>
     <string name="my_top_tracks">最喜爱的歌曲</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -24,7 +24,6 @@
     <string name="songs">歌曲</string>
     <string name="playlists">播放列表</string>
     <string name="unplayable_file">\u65e0\u6cd5\u64ad\u653e\u8be5\u6b4c\u66f2\u3002</string>
-    <string name="audio_focus_denied">无法获取音频焦点。</string>
     <string name="album">专辑</string>
     <string name="label_details">详情</string>
     <string name="label_file_name">文件名</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -25,7 +25,6 @@
     <string name="songs">歌曲</string>
     <string name="playlists">播放清單</string>
     <string name="unplayable_file">\u7121\u6cd5\u64ad\u653e\u9019\u9996\u6b4c\u3002</string>
-    <string name="audio_focus_denied">無法獲得音訊焦點。</string>
     <string name="album">專輯</string>
     <string name="label_details">詳細資訊</string>
     <string name="label_file_name">檔案名稱</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -68,7 +68,6 @@
     <string name="pref_title_blur_album_art">將專輯圖片模糊化</string>
     <string name="pref_title_colored_notification">彩色的狀態列</string>
     <string name="pref_title_classic_notification">經典通知樣式</string>
-    <string name="pref_title_audio_ducking">在焦點音訊響起時降低音量</string>
     <string name="pref_title_remember_tab">記住最後開啟的頁面</string>
     <string name="pref_title_remember_shuffle">記住隨機播放</string>
     <string name="delete_action">刪除</string>
@@ -93,7 +92,6 @@
     <string name="pref_summary_classic_notification">使用經典通知樣式</string>
     <string name="pref_summary_colored_notification">"\u72c0\u614b\u5217\u984f\u8272\u8207\u5c08\u8f2f\u5716\u7247\u984f\u8272\u4e00\u81f4"</string>
     <string name="pref_summary_colored_shortcuts">將主色調設為應用快捷方式的顏色</string>
-    <string name="pref_summary_audio_ducking">通知鈴聲、導航語音等。</string>
     <string name="pref_summary_remember_tab">開啟時顯示最後使用的頁面</string>
     <string name="pref_summary_remember_shuffle">當選擇新歌曲列表時維持隨機播放模式</string>
     <string name="last_added">最後新增</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -121,7 +121,6 @@
     <string name="pref_title_maximum_bitrate">Maximum Bitrate</string>
     <string name="pref_title_classic_notification">Classic Design</string>
     <string name="pref_title_colored_notification">Colored Notification</string>
-    <string name="pref_title_audio_ducking">Audio Ducking</string>
     <string name="pref_title_remember_tab">Remember Tab</string>
     <string name="pref_title_remember_shuffle">Remember Shuffle</string>
     <string name="pref_title_remember_queue">Remember Queue</string>
@@ -136,7 +135,6 @@
     <string name="pref_summary_blur_album_art">Blurs the album cover on the lock screen. This can cause problems with third party apps and widgets.</string>
     <string name="pref_summary_classic_notification">Use the classic notification design.</string>
     <string name="pref_summary_colored_notification">"Colors the notification with a vibrant color taken from the album cover."</string>
-    <string name="pref_summary_audio_ducking">Decrease the volume for notifications and other system sounds.</string>
     <string name="pref_summary_remember_shuffle">Shuffle mode will stay on when selecting a new list of songs for the queue.</string>
     <string name="pref_summary_remember_queue">Save the queue when closing the app so it can persist across sessions.</string>
     <string name="pref_summary_colored_shortcuts">Colors the app shortcuts in the primary color.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,7 +6,6 @@
     <string name="currently_listening_to_x_by_x">Currently listening to %1$s by %2$s.</string>
     <string name="the_audio_file">The audio file</string>
     <string name="unplayable_file">Couldn\'t play this song.</string>
-    <string name="audio_focus_denied">Audio focus denied.</string>
     <string name="error_share_file">There was an error sharing the file.</string>
     <string name="error_version">Please update your server to the latest version.</string>
 

--- a/app/src/main/res/xml/pref_playback.xml
+++ b/app/src/main/res/xml/pref_playback.xml
@@ -32,13 +32,6 @@
         <SwitchPreference
             app:iconSpaceReserved="false"
             android:defaultValue="true"
-            android:key="audio_ducking"
-            android:summary="@string/pref_summary_audio_ducking"
-            android:title="@string/pref_title_audio_ducking" />
-
-        <SwitchPreference
-            app:iconSpaceReserved="false"
-            android:defaultValue="true"
             android:key="remember_shuffle"
             android:summary="@string/pref_summary_remember_shuffle"
             android:title="@string/pref_title_remember_shuffle" />


### PR DESCRIPTION
ExoPlayer can handle audio focus, which makes pretty much all the manual handling obsolete. One important thing to note is that this would remove the setting to disable audio ducking, because ExoPlayer always lowers volume on incoming notifications or navigation tts. This also fixed #62.