### PR TITLE
Fix audio focus - notfication and widgets

### DIFF
--- a/app/src/main/java/com/dkanada/gramophone/service/playback/LocalPlayer.java
+++ b/app/src/main/java/com/dkanada/gramophone/service/playback/LocalPlayer.java
@@ -52,6 +52,12 @@ public class LocalPlayer implements Playback {
         }
 
         @Override
+        public void onPlaybackSuppressionReasonChanged(@Player.PlaybackSuppressionReason int playbackSuppressionReason) {
+            Log.i(TAG, String.format("onPlaybackSuppressionReasonChanged: %d", playbackSuppressionReason));
+            if (callbacks != null) callbacks.onStateChanged(Player.STATE_READY);
+        }
+
+        @Override
         public void onMediaItemTransition(MediaItem mediaItem, int reason) {
             Log.i(TAG, String.format("onMediaItemTransition: %s %d", mediaItem, reason));
 
@@ -164,7 +170,7 @@ public class LocalPlayer implements Playback {
 
     @Override
     public boolean isPlaying() {
-        return exoPlayer.isPlaying() || exoPlayer.getPlayWhenReady();
+        return exoPlayer.getPlayWhenReady() && exoPlayer.getPlaybackSuppressionReason() == Player.PLAYBACK_SUPPRESSION_REASON_NONE;
     }
 
     @Override


### PR DESCRIPTION
This fixes the notification and widget issues introduced in #156. This also changes the behavior of isPlaying() in LocalPlayer to give back false on a transient focus loss.