### PR TITLE
Added check for slide value

### DIFF
--- a/app/src/main/java/com/dkanada/gramophone/fragments/player/card/CardPlayerFragment.java
+++ b/app/src/main/java/com/dkanada/gramophone/fragments/player/card/CardPlayerFragment.java
@@ -292,7 +292,7 @@ public class CardPlayerFragment extends AbsPlayerFragment implements PlayerAlbum
 
     @Override
     public void onPanelSlide(View view, float slide) {
-        // the isInfinite and isNan check fixes a bug where the app crashes dues to an invalid slide value
+        // the isInfinite and isNan check fixes a bug where the app crashes due to an invalid slide value
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && !Float.isInfinite(slide) && !Float.isNaN(slide)) {
             float density = getResources().getDisplayMetrics().density;
             binding.playingQueueCard.setCardElevation((6 * slide + 2) * density);

--- a/app/src/main/java/com/dkanada/gramophone/fragments/player/card/CardPlayerFragment.java
+++ b/app/src/main/java/com/dkanada/gramophone/fragments/player/card/CardPlayerFragment.java
@@ -292,7 +292,8 @@ public class CardPlayerFragment extends AbsPlayerFragment implements PlayerAlbum
 
     @Override
     public void onPanelSlide(View view, float slide) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
+                && !(Float.isInfinite(slide) || Float.isNaN(slide))) {
             float density = getResources().getDisplayMetrics().density;
             binding.playingQueueCard.setCardElevation((6 * slide + 2) * density);
             playbackControlsFragment.binding.playerPlayPauseFab.setElevation((2 * Math.max(0, (1 - (slide * 16))) + 2) * density);

--- a/app/src/main/java/com/dkanada/gramophone/fragments/player/card/CardPlayerFragment.java
+++ b/app/src/main/java/com/dkanada/gramophone/fragments/player/card/CardPlayerFragment.java
@@ -292,8 +292,8 @@ public class CardPlayerFragment extends AbsPlayerFragment implements PlayerAlbum
 
     @Override
     public void onPanelSlide(View view, float slide) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
-                && !(Float.isInfinite(slide) || Float.isNaN(slide))) {
+        // the isInfinite and isNan check fixes a bug where the app crashes dues to an invalid slide value
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && !Float.isInfinite(slide) && !Float.isNaN(slide)) {
             float density = getResources().getDisplayMetrics().density;
             binding.playingQueueCard.setCardElevation((6 * slide + 2) * density);
             playbackControlsFragment.binding.playerPlayPauseFab.setElevation((2 * Math.max(0, (1 - (slide * 16))) + 2) * density);


### PR DESCRIPTION
This check was added to resolve the following issue: 
- #187 

Please follow the steps in the bug report to reproduce.

The following logs were gathered when the bug was occurring (after applying the fix). To reproduce these logs insert the following statement under line 294 of CardPlayerFragment.java:
`Log.i("testingo", String.valueOf(slide));`

![logs](https://user-images.githubusercontent.com/60099557/133067808-bd63c926-3001-413f-a8d9-623e5bd66252.png)
