### PR TITLE
Expand list of illegal characters for downloaded filenames

### DIFF
--- a/app/src/main/java/com/dkanada/gramophone/util/MusicUtil.java
+++ b/app/src/main/java/com/dkanada/gramophone/util/MusicUtil.java
@@ -86,7 +86,7 @@ public class MusicUtil {
 
     @NonNull
     public static String ascii(String string) {
-        return string == null ? "Unknown" : string.replaceAll("[\\x00-\\x1F\\x2F\\x7F]", "");
+        return string == null ? "Unknown" : string.replaceAll("[\\x00-\\x1F\\x22\\x2A\\x2F\\x3A\\x3C\\x3E\\x3F\\x5C\\x7C\\x7F]", "");
     }
 
     @NonNull


### PR DESCRIPTION
Even though theoretically all these characters are "allowed" on a Unix filesystem, when I try to download a song with a question mark in its title, either the download hangs or the file creation fails. Something like that. The file never shows up and the download never progresses.

Here are the characters I've added to the blacklist: `"*:<>?\|`

So it should now remove any ASCII character not allowed in filenames on Unix, OS X, or Windows.

There are some other characters like `@` or `#` that are questionable because of networking stuff, but I left those alone. There isn't a definitive answer on which characters don't belong in filenames, but I think this is a good minimum.