### PR TITLE
Move setHasOptionsMenu to onCreateView

### DIFF
--- a/app/src/main/java/com/dkanada/gramophone/fragments/library/AbsLibraryPagerFragment.java
+++ b/app/src/main/java/com/dkanada/gramophone/fragments/library/AbsLibraryPagerFragment.java
@@ -1,18 +1,10 @@
 package com.dkanada.gramophone.fragments.library;
 
-import android.os.Bundle;
-
 import com.dkanada.gramophone.fragments.AbsMusicServiceFragment;
 import com.dkanada.gramophone.fragments.main.LibraryFragment;
 
 public class AbsLibraryPagerFragment extends AbsMusicServiceFragment {
     public LibraryFragment getLibraryFragment() {
         return (LibraryFragment) getParentFragment();
-    }
-
-    @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setHasOptionsMenu(true);
     }
 }

--- a/app/src/main/java/com/dkanada/gramophone/fragments/library/AbsLibraryPagerRecyclerViewFragment.java
+++ b/app/src/main/java/com/dkanada/gramophone/fragments/library/AbsLibraryPagerRecyclerViewFragment.java
@@ -31,6 +31,7 @@ public abstract class AbsLibraryPagerRecyclerViewFragment<A extends RecyclerView
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        setHasOptionsMenu(true);
         binding = FragmentMainActivityRecyclerViewBinding.inflate(getLayoutInflater(), container, false);
 
         return binding.getRoot();

--- a/app/src/main/java/com/dkanada/gramophone/fragments/main/AbsMainActivityFragment.java
+++ b/app/src/main/java/com/dkanada/gramophone/fragments/main/AbsMainActivityFragment.java
@@ -1,7 +1,5 @@
 package com.dkanada.gramophone.fragments.main;
 
-import android.os.Bundle;
-
 import androidx.fragment.app.Fragment;
 
 import com.dkanada.gramophone.activities.MainActivity;
@@ -9,11 +7,5 @@ import com.dkanada.gramophone.activities.MainActivity;
 public abstract class AbsMainActivityFragment extends Fragment {
     public MainActivity getMainActivity() {
         return (MainActivity) getActivity();
-    }
-
-    @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setHasOptionsMenu(true);
     }
 }

--- a/app/src/main/java/com/dkanada/gramophone/fragments/main/LibraryFragment.java
+++ b/app/src/main/java/com/dkanada/gramophone/fragments/main/LibraryFragment.java
@@ -47,6 +47,7 @@ public class LibraryFragment extends AbsMainActivityFragment implements ViewPage
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        setHasOptionsMenu(true);
         binding = FragmentLibraryBinding.inflate(inflater);
 
         return binding.getRoot();


### PR DESCRIPTION
Commit 06c40d3 replaced the deprecated onActivityCreated with onCreate.
Apparently this leads to issues like backgrounds turning white on
screen rotation.
Fix: use onCreateView() to call setHasOptionsMenu  instead, move to
AbsMainActivityFragment and LibraryFragment respectively because
onCreateView gets overridden there.

Should fix #167 and/or #173