### PR TITLE
Add gain adjustment

### DIFF
--- a/app/src/main/java/com/dkanada/gramophone/service/MusicService.java
+++ b/app/src/main/java/com/dkanada/gramophone/service/MusicService.java
@@ -238,6 +238,7 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
 
         playback = new LocalPlayer(this);
         playback.setListener(playbackCallbacks);
+        playback.setVolume(PreferenceUtil.getInstance(this).getGainOffset());
 
         queueManager = new QueueManager(this, queueCallbacks);
 
@@ -673,6 +674,9 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
             case PreferenceUtil.CLASSIC_NOTIFICATION:
                 initNotification();
                 updateNotification();
+                break;
+            case PreferenceUtil.GAIN_OFFSET:
+                playback.setVolume(PreferenceUtil.getInstance(this).getGainOffset());
                 break;
         }
     }

--- a/app/src/main/java/com/dkanada/gramophone/util/PreferenceUtil.java
+++ b/app/src/main/java/com/dkanada/gramophone/util/PreferenceUtil.java
@@ -81,6 +81,7 @@ public final class PreferenceUtil {
     public static final String MAXIMUM_BITRATE = "maximum_bitrate";
     public static final String REMEMBER_SHUFFLE = "remember_shuffle";
     public static final String REMEMBER_QUEUE = "remember_queue";
+    public static final String GAIN_OFFSET = "gain_offset";
 
     public static final String LOCATION_DOWNLOAD = "location_download";
     public static final String LOCATION_CACHE = "location_cache";
@@ -252,6 +253,10 @@ public final class PreferenceUtil {
 
     public final boolean getRememberQueue() {
         return mPreferences.getBoolean(REMEMBER_QUEUE, true);
+    }
+
+    public final int getGainOffset() {
+        return mPreferences.getInt(GAIN_OFFSET, 100);
     }
 
     public final boolean getShowAlbumCover() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -128,6 +128,7 @@
     <string name="pref_title_download_location">Download Location</string>
     <string name="pref_title_image_cache_size">Images</string>
     <string name="pref_title_media_cache_size">Media</string>
+    <string name="pref_title_gain_adjustment">Gain Adjustment</string>
 
     <string name="pref_summary_primary_color">The primary theme color for control elements.</string>
     <string name="pref_summary_accent_color">An alternate color used to accent elements.</string>
@@ -141,6 +142,7 @@
     <string name="pref_summary_remember_tab">Go to the last opened tab on launch.</string>
     <string name="pref_summary_categories">Configure visibility and order of display categories.</string>
     <string name="pref_summary_direct_play_codecs">Disable direct play codecs to force transcoding.</string>
+    <string name="pref_summary_gain_adjustment">Adjust the gain of the music player\'s output</string>
 
     <string name="delete_action">Delete</string>
     <string name="remove_action">Remove</string>

--- a/app/src/main/res/xml/pref_playback.xml
+++ b/app/src/main/res/xml/pref_playback.xml
@@ -45,6 +45,13 @@
             android:summary="@string/pref_summary_remember_queue"
             android:title="@string/pref_title_remember_queue" />
 
+        <SeekBarPreference
+            app:iconSpaceReserved="false"
+            android:defaultValue="100"
+            android:key="gain_offset"
+            android:summary="@string/pref_summary_gain_adjustment"
+            android:title="@string/pref_title_gain_adjustment"/>
+
     </com.dkanada.gramophone.views.settings.JellyPreferenceCategory>
 
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
As I had requested in issue #230, I've added a setting to adjust the global volume output of the player separate from the system volume. If you'd like me to make any changes before merge I'd be happy to.