### PR TITLE
Add support for multiple artists

### DIFF
--- a/app/src/main/java/com/dkanada/gramophone/activities/SearchActivity.java
+++ b/app/src/main/java/com/dkanada/gramophone/activities/SearchActivity.java
@@ -25,6 +25,7 @@ import com.dkanada.gramophone.util.QueryUtil;
 import com.dkanada.gramophone.util.Util;
 
 import org.jellyfin.apiclient.model.querying.ItemQuery;
+import org.jellyfin.apiclient.model.search.SearchQuery;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -42,6 +43,8 @@ public class SearchActivity extends AbsMusicContentActivity implements SearchVie
 
     private SearchAdapter adapter;
     private String query;
+
+    private List<Object> sortedResults;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -131,9 +134,16 @@ public class SearchActivity extends AbsMusicContentActivity implements SearchVie
 
     private void search(@NonNull String query) {
         this.query = query;
+        if (this.query.isEmpty()) {
+            return;
+        }
+        sortedResults = new ArrayList<>();
 
         ItemQuery itemQuery = new ItemQuery();
         itemQuery.setSearchTerm(query);
+
+        SearchQuery searchQuery = new SearchQuery();
+        searchQuery.setSearchTerm(query);
 
         MediaCallback<Object> callback = media -> {
             List<Artist> artists = new ArrayList<>();
@@ -154,15 +164,15 @@ public class SearchActivity extends AbsMusicContentActivity implements SearchVie
             Collections.sort(albums, (one, two) -> one.title.compareTo(two.title));
             Collections.sort(songs, (one, two) -> one.title.compareTo(two.title));
 
-            List<Object> sortedData = new ArrayList<>();
-            sortedData.addAll(artists);
-            sortedData.addAll(albums);
-            sortedData.addAll(songs);
+            sortedResults.addAll(artists);
+            sortedResults.addAll(albums);
+            sortedResults.addAll(songs);
 
-            adapter.swapDataSet(sortedData);
+            adapter.swapDataSet(sortedResults);
         };
 
         QueryUtil.getItems(itemQuery, callback);
+        QueryUtil.getSearchHints(searchQuery, callback);
     }
 
     @Override

--- a/app/src/main/java/com/dkanada/gramophone/adapter/MusicLibraryPagerAdapter.java
+++ b/app/src/main/java/com/dkanada/gramophone/adapter/MusicLibraryPagerAdapter.java
@@ -10,6 +10,7 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentPagerAdapter;
 
+import com.dkanada.gramophone.fragments.library.AlbumArtistsFragment;
 import com.dkanada.gramophone.fragments.library.FavoritesFragment;
 import com.dkanada.gramophone.model.Category;
 import com.dkanada.gramophone.fragments.library.AlbumsFragment;
@@ -155,6 +156,7 @@ public class MusicLibraryPagerAdapter extends FragmentPagerAdapter {
         SONGS(SongsFragment.class),
         ALBUMS(AlbumsFragment.class),
         ARTISTS(ArtistsFragment.class),
+        ALBUMARTISTS(AlbumArtistsFragment.class),
         GENRES(GenresFragment.class),
         PLAYLISTS(PlaylistsFragment.class),
         FAVORITES(FavoritesFragment.class);

--- a/app/src/main/java/com/dkanada/gramophone/adapter/song/SongAdapter.java
+++ b/app/src/main/java/com/dkanada/gramophone/adapter/song/SongAdapter.java
@@ -205,7 +205,7 @@ public class SongAdapter extends AbsMultiSelectAdapter<SongAdapter.ViewHolder, S
                 sectionName = dataSet.get(position).albumName;
                 break;
             case ARTIST:
-                sectionName = dataSet.get(position).artistName;
+                sectionName = dataSet.get(position).getArtistNames();
                 break;
             case YEAR:
                 return MusicUtil.getYearString(dataSet.get(position).year);

--- a/app/src/main/java/com/dkanada/gramophone/database/Converters.java
+++ b/app/src/main/java/com/dkanada/gramophone/database/Converters.java
@@ -1,0 +1,22 @@
+package com.dkanada.gramophone.database;
+
+import androidx.room.TypeConverter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class Converters {
+    @TypeConverter
+    public static ArrayList<String> fromString(String value) {
+        List<String> items = Arrays.asList(value.split("\\s*, \\s*"));
+        ArrayList<String> arrayList = new ArrayList<>();
+        arrayList.addAll(items);
+        return arrayList;
+    }
+
+    @TypeConverter
+    public static String fromArrayList(ArrayList<String> list) {
+        return list.toString().substring(1,list.toString().length()-1);
+    }
+}

--- a/app/src/main/java/com/dkanada/gramophone/dialogs/SongShareDialog.java
+++ b/app/src/main/java/com/dkanada/gramophone/dialogs/SongShareDialog.java
@@ -28,7 +28,7 @@ public class SongShareDialog extends DialogFragment {
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         final Song song = getArguments().getParcelable("song");
-        final String currentlyListening = getString(R.string.currently_listening_to_x_by_x, song.title, song.artistName);
+        final String currentlyListening = getString(R.string.currently_listening_to_x_by_x, song.title, song.getArtistNames());
         return new MaterialDialog.Builder(requireActivity())
                 .title(R.string.what_do_you_want_to_share)
                 .items(getString(R.string.the_audio_file), "\u201C" + currentlyListening + "\u201D")

--- a/app/src/main/java/com/dkanada/gramophone/fragments/library/AbsArtistsFragment.java
+++ b/app/src/main/java/com/dkanada/gramophone/fragments/library/AbsArtistsFragment.java
@@ -1,0 +1,142 @@
+package com.dkanada.gramophone.fragments.library;
+
+import androidx.annotation.LayoutRes;
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.GridLayoutManager;
+
+import com.dkanada.gramophone.App;
+import com.dkanada.gramophone.R;
+import com.dkanada.gramophone.adapter.artist.ArtistAdapter;
+import com.dkanada.gramophone.model.Artist;
+import com.dkanada.gramophone.model.SortMethod;
+import com.dkanada.gramophone.model.SortOrder;
+import com.dkanada.gramophone.util.PreferenceUtil;
+import com.dkanada.gramophone.util.QueryUtil;
+
+import org.jellyfin.apiclient.model.querying.ArtistsQuery;
+import org.jellyfin.apiclient.model.querying.ItemFields;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class AbsArtistsFragment extends AbsLibraryPagerRecyclerViewCustomGridSizeFragment<ArtistAdapter, GridLayoutManager, ArtistsQuery> {
+    @NonNull
+    @Override
+    protected GridLayoutManager createLayoutManager() {
+        return new GridLayoutManager(getActivity(), getGridSize());
+    }
+
+    @NonNull
+    @Override
+    protected ArtistAdapter createAdapter() {
+        int itemLayoutRes = getItemLayoutRes();
+        notifyLayoutResChanged(itemLayoutRes);
+
+        List<Artist> dataSet = getAdapter() == null ? new ArrayList<>() : getAdapter().getDataSet();
+        return new ArtistAdapter(getLibraryFragment().getMainActivity(), dataSet, itemLayoutRes, loadUsePalette(), getLibraryFragment().getMainActivity());
+    }
+
+    @NonNull
+    @Override
+    protected ArtistsQuery createQuery() {
+        ArtistsQuery query = new ArtistsQuery();
+
+        query.setFields(new ItemFields[]{ItemFields.Genres});
+        query.setUserId(App.getApiClient().getCurrentUserId());
+        query.setRecursive(true);
+        query.setLimit(PreferenceUtil.getInstance(App.getInstance()).getPageSize());
+        query.setStartIndex(getAdapter().getItemCount());
+        query.setParentId(QueryUtil.currentLibrary.getId());
+
+        query.setSortBy(new String[]{PreferenceUtil.getInstance(App.getInstance()).getArtistSortMethod().getApi()});
+        query.setSortOrder(PreferenceUtil.getInstance(App.getInstance()).getArtistSortOrder().getApi());
+
+        return query;
+    }
+
+    @Override
+    protected abstract void loadItems(int index);
+
+    @Override
+    protected int getEmptyMessage() {
+        return R.string.no_artists;
+    }
+
+    @LayoutRes
+    protected int getItemLayoutRes() {
+        if (getGridSize() > getMaxGridSizeForList()) {
+            return R.layout.item_grid;
+        }
+
+        return R.layout.item_list_single_row;
+    }
+
+    @Override
+    protected SortMethod loadSortMethod() {
+        return PreferenceUtil.getInstance(getActivity()).getArtistSortMethod();
+    }
+
+    @Override
+    protected void saveSortMethod(SortMethod sortMethod) {
+        PreferenceUtil.getInstance(getActivity()).setArtistSortMethod(sortMethod);
+    }
+
+    @Override
+    protected void setSortMethod(SortMethod sortMethod) {
+    }
+
+    @Override
+    protected SortOrder loadSortOrder() {
+        return PreferenceUtil.getInstance(getActivity()).getArtistSortOrder();
+    }
+
+    @Override
+    protected void saveSortOrder(SortOrder sortOrder) {
+        PreferenceUtil.getInstance(getActivity()).setArtistSortOrder(sortOrder);
+    }
+
+    @Override
+    protected void setSortOrder(SortOrder sortOrder) {
+    }
+
+    @Override
+    protected int loadGridSize() {
+        return PreferenceUtil.getInstance(getActivity()).getArtistGridSize(requireActivity());
+    }
+
+    @Override
+    protected void saveGridSize(int gridSize) {
+        PreferenceUtil.getInstance(getActivity()).setArtistGridSize(gridSize);
+    }
+
+    @Override
+    protected int loadGridSizeLand() {
+        return PreferenceUtil.getInstance(getActivity()).getArtistGridSizeLand(requireActivity());
+    }
+
+    @Override
+    protected void saveGridSizeLand(int gridSize) {
+        PreferenceUtil.getInstance(getActivity()).setArtistGridSizeLand(gridSize);
+    }
+
+    @Override
+    protected void saveUsePalette(boolean usePalette) {
+        PreferenceUtil.getInstance(getActivity()).setArtistColoredFooters(usePalette);
+    }
+
+    @Override
+    public boolean loadUsePalette() {
+        return PreferenceUtil.getInstance(getActivity()).getArtistColoredFooters();
+    }
+
+    @Override
+    protected void setUsePalette(boolean usePalette) {
+        getAdapter().usePalette(usePalette);
+    }
+
+    @Override
+    protected void setGridSize(int gridSize) {
+        getLayoutManager().setSpanCount(gridSize);
+        getAdapter().notifyDataSetChanged();
+    }
+}

--- a/app/src/main/java/com/dkanada/gramophone/fragments/library/AlbumArtistsFragment.java
+++ b/app/src/main/java/com/dkanada/gramophone/fragments/library/AlbumArtistsFragment.java
@@ -7,9 +7,9 @@ import androidx.recyclerview.widget.GridLayoutManager;
 import com.dkanada.gramophone.App;
 import com.dkanada.gramophone.R;
 import com.dkanada.gramophone.adapter.artist.ArtistAdapter;
+import com.dkanada.gramophone.model.Artist;
 import com.dkanada.gramophone.model.SortMethod;
 import com.dkanada.gramophone.model.SortOrder;
-import com.dkanada.gramophone.model.Artist;
 import com.dkanada.gramophone.util.PreferenceUtil;
 import com.dkanada.gramophone.util.QueryUtil;
 
@@ -22,14 +22,14 @@ import org.jellyfin.apiclient.model.querying.ItemsResult;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ArtistsFragment extends AbsArtistsFragment {
+public class AlbumArtistsFragment extends AbsArtistsFragment {
 
     @Override
     protected void loadItems(int index) {
         ArtistsQuery query = getQuery();
         query.setStartIndex(index);
 
-        App.getApiClient().GetArtistsAsync(query, new Response<ItemsResult>() {
+        App.getApiClient().GetAlbumArtistsAsync(query, new Response<ItemsResult>() {
             @Override
             public void onResponse(ItemsResult result) {
                 if (index == 0) getAdapter().getDataSet().clear();
@@ -48,5 +48,4 @@ public class ArtistsFragment extends AbsArtistsFragment {
             }
         });
     }
-
 }

--- a/app/src/main/java/com/dkanada/gramophone/fragments/library/AlbumArtistsFragment.java
+++ b/app/src/main/java/com/dkanada/gramophone/fragments/library/AlbumArtistsFragment.java
@@ -1,26 +1,12 @@
 package com.dkanada.gramophone.fragments.library;
 
-import androidx.annotation.LayoutRes;
-import androidx.annotation.NonNull;
-import androidx.recyclerview.widget.GridLayoutManager;
-
 import com.dkanada.gramophone.App;
-import com.dkanada.gramophone.R;
-import com.dkanada.gramophone.adapter.artist.ArtistAdapter;
 import com.dkanada.gramophone.model.Artist;
-import com.dkanada.gramophone.model.SortMethod;
-import com.dkanada.gramophone.model.SortOrder;
-import com.dkanada.gramophone.util.PreferenceUtil;
-import com.dkanada.gramophone.util.QueryUtil;
 
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.querying.ArtistsQuery;
-import org.jellyfin.apiclient.model.querying.ItemFields;
 import org.jellyfin.apiclient.model.querying.ItemsResult;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class AlbumArtistsFragment extends AbsArtistsFragment {
 

--- a/app/src/main/java/com/dkanada/gramophone/fragments/library/ArtistsFragment.java
+++ b/app/src/main/java/com/dkanada/gramophone/fragments/library/ArtistsFragment.java
@@ -1,26 +1,12 @@
 package com.dkanada.gramophone.fragments.library;
 
-import androidx.annotation.LayoutRes;
-import androidx.annotation.NonNull;
-import androidx.recyclerview.widget.GridLayoutManager;
-
 import com.dkanada.gramophone.App;
-import com.dkanada.gramophone.R;
-import com.dkanada.gramophone.adapter.artist.ArtistAdapter;
-import com.dkanada.gramophone.model.SortMethod;
-import com.dkanada.gramophone.model.SortOrder;
 import com.dkanada.gramophone.model.Artist;
-import com.dkanada.gramophone.util.PreferenceUtil;
-import com.dkanada.gramophone.util.QueryUtil;
 
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.querying.ArtistsQuery;
-import org.jellyfin.apiclient.model.querying.ItemFields;
 import org.jellyfin.apiclient.model.querying.ItemsResult;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class ArtistsFragment extends AbsArtistsFragment {
 

--- a/app/src/main/java/com/dkanada/gramophone/model/Album.java
+++ b/app/src/main/java/com/dkanada/gramophone/model/Album.java
@@ -7,6 +7,7 @@ import androidx.annotation.NonNull;
 
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.entities.ImageType;
+import org.jellyfin.apiclient.model.search.SearchHint;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/app/src/main/java/com/dkanada/gramophone/model/Album.java
+++ b/app/src/main/java/com/dkanada/gramophone/model/Album.java
@@ -50,8 +50,8 @@ public class Album implements Parcelable {
         this.title = song.albumName;
         this.year = song.year;
 
-        this.artistId = song.artistId;
-        this.artistName = song.artistName;
+        this.artistId = song.albumArtistId;
+        this.artistName = song.albumArtistName;
 
         this.primary = song.primary;
         this.blurHash = song.blurHash;

--- a/app/src/main/java/com/dkanada/gramophone/model/Artist.java
+++ b/app/src/main/java/com/dkanada/gramophone/model/Artist.java
@@ -50,8 +50,8 @@ public class Artist implements Parcelable {
     }
 
     public Artist(Song song) {
-        this.id = song.artistId;
-        this.name = song.artistName;
+        this.id = song.albumArtistId != null ? song.albumArtistId : song.artistId.size() != 0 ? song.artistId.get(0) : null ;
+        this.name = song.albumArtistName != null ? song.albumArtistName : song.artistName.size() != 0 ? song.artistName.get(0) : null ;
         this.primary = this.id;
     }
 

--- a/app/src/main/java/com/dkanada/gramophone/model/Artist.java
+++ b/app/src/main/java/com/dkanada/gramophone/model/Artist.java
@@ -8,6 +8,7 @@ import androidx.annotation.NonNull;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.dto.GenreDto;
 import org.jellyfin.apiclient.model.entities.ImageType;
+import org.jellyfin.apiclient.model.search.SearchHint;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -41,6 +42,15 @@ public class Artist implements Parcelable {
                 genres.add(new Genre(genre));
             }
         }
+    }
+
+    public Artist(SearchHint searchHint) {
+        this.id = searchHint.getItemId();
+        this.name = searchHint.getName();
+        this.primary = searchHint.getPrimaryImageTag() == null || searchHint.getPrimaryImageTag().isEmpty() ? null : this.id;
+        this.genres = new ArrayList<>();
+        this.albums = new ArrayList<>();
+        this.songs = new ArrayList<>();
     }
 
     public Artist(Album album) {

--- a/app/src/main/java/com/dkanada/gramophone/model/Category.java
+++ b/app/src/main/java/com/dkanada/gramophone/model/Category.java
@@ -8,6 +8,7 @@ public enum Category {
     SONGS(R.string.songs),
     ALBUMS(R.string.albums),
     ARTISTS(R.string.artists),
+    ALBUMARTISTS(R.string.albumartists),
     GENRES(R.string.genres),
     PLAYLISTS(R.string.playlists),
     FAVORITES(R.string.favorites);

--- a/app/src/main/java/com/dkanada/gramophone/model/Song.java
+++ b/app/src/main/java/com/dkanada/gramophone/model/Song.java
@@ -7,14 +7,21 @@ import androidx.annotation.NonNull;
 import androidx.room.ColumnInfo;
 import androidx.room.Entity;
 import androidx.room.PrimaryKey;
+import androidx.room.TypeConverters;
+
+import com.dkanada.gramophone.database.Converters;
 
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.dto.MediaSourceInfo;
+import org.jellyfin.apiclient.model.dto.NameIdPair;
 import org.jellyfin.apiclient.model.entities.ImageType;
 import org.jellyfin.apiclient.model.entities.MediaStream;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
-
+@TypeConverters({Converters.class})
 @Entity(tableName = "songs")
 public class Song implements Parcelable {
     @NonNull
@@ -29,8 +36,11 @@ public class Song implements Parcelable {
     public String albumId;
     public String albumName;
 
-    public String artistId;
-    public String artistName;
+    public ArrayList<String> artistId;
+    public ArrayList<String> artistName;
+
+    public String albumArtistId;
+    public String albumArtistName;
 
     public String primary;
     public String blurHash;
@@ -52,6 +62,10 @@ public class Song implements Parcelable {
     @ColumnInfo(defaultValue = "1")
     public boolean cache;
 
+    public String getArtistNames(){
+        return this.artistName.toString().substring(1,this.artistName.toString().length()-1);
+    }
+
     public Song() {
         this.id = UUID.randomUUID().toString();
     }
@@ -67,12 +81,21 @@ public class Song implements Parcelable {
         this.albumId = itemDto.getAlbumId();
         this.albumName = itemDto.getAlbum();
 
+        this.artistId = new ArrayList<>();
+        this.artistName = new ArrayList<>();
         if (itemDto.getArtistItems().size() != 0) {
-            this.artistId = itemDto.getArtistItems().get(0).getId();
-            this.artistName = itemDto.getArtistItems().get(0).getName();
+            for (NameIdPair artistItem:itemDto.getArtistItems()) {
+                this.artistId.add(artistItem.getId());
+                this.artistName.add(artistItem.getName());
+            }
         } else if (itemDto.getAlbumArtists().size() != 0) {
-            this.artistId = itemDto.getAlbumArtists().get(0).getId();
-            this.artistName = itemDto.getAlbumArtists().get(0).getName();
+            this.artistId.add(itemDto.getAlbumArtists().get(0).getId());
+            this.artistName.add(itemDto.getAlbumArtists().get(0).getName());
+        }
+
+        if (itemDto.getAlbumArtists().size() != 0) {
+            this.albumArtistId = itemDto.getAlbumArtists().get(0).getId();
+            this.albumArtistName = itemDto.getAlbumArtists().get(0).getName();
         }
 
         this.primary = itemDto.getAlbumPrimaryImageTag() != null ? albumId : null;
@@ -141,8 +164,11 @@ public class Song implements Parcelable {
         dest.writeString(this.albumId);
         dest.writeString(this.albumName);
 
-        dest.writeString(this.artistId);
-        dest.writeString(this.artistName);
+        dest.writeList (this.artistId);
+        dest.writeList (this.artistName);
+
+        dest.writeString(this.albumArtistId);
+        dest.writeString(this.albumArtistName);
 
         dest.writeString(this.primary);
         dest.writeString(Boolean.toString(favorite));
@@ -171,8 +197,13 @@ public class Song implements Parcelable {
         this.albumId = in.readString();
         this.albumName = in.readString();
 
-        this.artistId = in.readString();
-        this.artistName = in.readString();
+        this.artistId = new ArrayList<>();
+        in.readList(this.artistId, List.class.getClassLoader());
+        this.artistName = new ArrayList<>();
+        in.readList(this.artistName, List.class.getClassLoader());
+
+        this.albumArtistId = in.readString();
+        this.albumArtistName = in.readString();
 
         this.primary = in.readString();
         this.favorite = Boolean.parseBoolean(in.readString());

--- a/app/src/main/java/com/dkanada/gramophone/model/Song.java
+++ b/app/src/main/java/com/dkanada/gramophone/model/Song.java
@@ -16,6 +16,7 @@ import org.jellyfin.apiclient.model.dto.MediaSourceInfo;
 import org.jellyfin.apiclient.model.dto.NameIdPair;
 import org.jellyfin.apiclient.model.entities.ImageType;
 import org.jellyfin.apiclient.model.entities.MediaStream;
+import org.jellyfin.apiclient.model.search.SearchHint;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -126,6 +127,7 @@ public class Song implements Parcelable {
             }
         }
     }
+
 
     @Override
     public boolean equals(Object o) {

--- a/app/src/main/java/com/dkanada/gramophone/service/MusicService.java
+++ b/app/src/main/java/com/dkanada/gramophone/service/MusicService.java
@@ -505,8 +505,8 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
         }
 
         final MediaMetadataCompat.Builder metaData = new MediaMetadataCompat.Builder()
-            .putString(MediaMetadataCompat.METADATA_KEY_ARTIST, song.artistName)
-            .putString(MediaMetadataCompat.METADATA_KEY_ALBUM_ARTIST, song.artistName)
+            .putString(MediaMetadataCompat.METADATA_KEY_ARTIST, song.getArtistNames())
+            .putString(MediaMetadataCompat.METADATA_KEY_ALBUM_ARTIST, song.albumArtistName)
             .putString(MediaMetadataCompat.METADATA_KEY_ALBUM, song.albumName)
             .putString(MediaMetadataCompat.METADATA_KEY_TITLE, song.title)
             .putLong(MediaMetadataCompat.METADATA_KEY_DURATION, song.duration)

--- a/app/src/main/java/com/dkanada/gramophone/service/notifications/PlayingNotificationMarshmallow.java
+++ b/app/src/main/java/com/dkanada/gramophone/service/notifications/PlayingNotificationMarshmallow.java
@@ -45,20 +45,20 @@ public class PlayingNotificationMarshmallow extends PlayingNotification {
         final RemoteViews notificationLayout = new RemoteViews(service.getPackageName(), R.layout.notification);
         final RemoteViews notificationLayoutBig = new RemoteViews(service.getPackageName(), R.layout.notification_big);
 
-        if (TextUtils.isEmpty(song.title) && TextUtils.isEmpty(song.artistName)) {
+        if (TextUtils.isEmpty(song.title) && song.getArtistNames().isEmpty()) {
             notificationLayout.setViewVisibility(R.id.media_titles, View.INVISIBLE);
         } else {
             notificationLayout.setViewVisibility(R.id.media_titles, View.VISIBLE);
             notificationLayout.setTextViewText(R.id.title, song.title);
-            notificationLayout.setTextViewText(R.id.text, song.artistName);
+            notificationLayout.setTextViewText(R.id.text, song.getArtistNames());
         }
 
-        if (TextUtils.isEmpty(song.title) && TextUtils.isEmpty(song.artistName) && TextUtils.isEmpty(song.albumName)) {
+        if (TextUtils.isEmpty(song.title) && song.getArtistNames().isEmpty() && TextUtils.isEmpty(song.albumName)) {
             notificationLayoutBig.setViewVisibility(R.id.media_titles, View.INVISIBLE);
         } else {
             notificationLayoutBig.setViewVisibility(R.id.media_titles, View.VISIBLE);
             notificationLayoutBig.setTextViewText(R.id.title, song.title);
-            notificationLayoutBig.setTextViewText(R.id.text, song.artistName);
+            notificationLayoutBig.setTextViewText(R.id.text, song.getArtistNames());
             notificationLayoutBig.setTextViewText(R.id.text2, song.albumName);
         }
 

--- a/app/src/main/java/com/dkanada/gramophone/util/MusicUtil.java
+++ b/app/src/main/java/com/dkanada/gramophone/util/MusicUtil.java
@@ -80,7 +80,7 @@ public class MusicUtil {
     public static String getFileUri(Song song) {
         File root = new File(PreferenceUtil.getInstance(App.getInstance()).getLocationDownload(), "music");
 
-        String path = "/" + ascii(song.artistName) + "/" + ascii(song.albumName);
+        String path = "/" + ascii(song.albumArtistName) + "/" + ascii(song.albumName);
         String name = "/" + song.discNumber + "." + song.trackNumber + " - " + ascii(song.title) + "." + song.container;
 
         return root + path + name;

--- a/app/src/main/java/com/dkanada/gramophone/util/QueryUtil.java
+++ b/app/src/main/java/com/dkanada/gramophone/util/QueryUtil.java
@@ -16,6 +16,9 @@ import org.jellyfin.apiclient.model.querying.ItemFields;
 import org.jellyfin.apiclient.model.querying.ItemQuery;
 import org.jellyfin.apiclient.model.querying.ItemsByNameQuery;
 import org.jellyfin.apiclient.model.querying.ItemsResult;
+import org.jellyfin.apiclient.model.search.SearchHint;
+import org.jellyfin.apiclient.model.search.SearchHintResult;
+import org.jellyfin.apiclient.model.search.SearchQuery;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -87,7 +90,7 @@ public class QueryUtil {
     }
 
     public static void getItems(ItemQuery query, MediaCallback<Object> callback) {
-        query.setIncludeItemTypes(new String[]{"MusicArtist", "MusicAlbum", "Audio"});
+        query.setIncludeItemTypes(new String[]{"MusicAlbum", "Audio"});
         query.setFields(new ItemFields[]{ItemFields.MediaSources});
         query.setUserId(App.getApiClient().getCurrentUserId());
         query.setLimit(40);
@@ -97,9 +100,7 @@ public class QueryUtil {
             public void onResponse(ItemsResult result) {
                 List<Object> items = new ArrayList<>();
                 for (BaseItemDto itemDto : result.getItems()) {
-                    if (itemDto.getBaseItemType() == BaseItemType.MusicArtist) {
-                        items.add(new Artist(itemDto));
-                    } else if (itemDto.getBaseItemType() == BaseItemType.MusicAlbum) {
+                    if (itemDto.getBaseItemType() == BaseItemType.MusicAlbum) {
                         items.add(new Album(itemDto));
                     } else {
                         items.add(new Song(itemDto));
@@ -112,6 +113,27 @@ public class QueryUtil {
             @Override
             public void onError(Exception exception) {
                 exception.printStackTrace();
+            }
+        });
+    }
+
+    public static void getSearchHints(SearchQuery query, MediaCallback<Object> callback) {
+        query.setIncludeItemTypes(new String[]{"MusicArtist"});
+        query.setUserId(App.getApiClient().getCurrentUserId());
+        query.setLimit(40);
+        query.setIncludeMedia(true);
+        query.setIncludeArtists(true);
+        App.getApiClient().GetSearchHintsAsync(query, new Response<SearchHintResult>() {
+            @Override
+            public void onResponse(SearchHintResult response) {
+                List<Object> items = new ArrayList<>();
+                for (SearchHint searchHint : response.getSearchHints()) {
+                    if (searchHint.getType().equals("MusicArtist") ) {
+                        items.add(new Artist(searchHint));
+                    }
+                }
+
+                callback.onLoadMedia(items);
             }
         });
     }

--- a/app/src/main/java/com/dkanada/gramophone/views/widgets/AppWidgetAlbum.java
+++ b/app/src/main/java/com/dkanada/gramophone/views/widgets/AppWidgetAlbum.java
@@ -70,7 +70,7 @@ public class AppWidgetAlbum extends BaseAppWidget {
         final boolean isPlaying = service.isPlaying();
         final Song song = service.queueManager.getCurrentSong();
 
-        if (TextUtils.isEmpty(song.title) && TextUtils.isEmpty(song.artistName)) {
+        if (TextUtils.isEmpty(song.title) && song.getArtistNames().isEmpty()) {
             appWidgetView.setViewVisibility(R.id.media_titles, View.INVISIBLE);
         } else {
             appWidgetView.setViewVisibility(R.id.media_titles, View.VISIBLE);

--- a/app/src/main/java/com/dkanada/gramophone/views/widgets/AppWidgetCard.java
+++ b/app/src/main/java/com/dkanada/gramophone/views/widgets/AppWidgetCard.java
@@ -68,7 +68,7 @@ public class AppWidgetCard extends BaseAppWidget {
         final boolean isPlaying = service.isPlaying();
         final Song song = service.queueManager.getCurrentSong();
 
-        if (TextUtils.isEmpty(song.title) && TextUtils.isEmpty(song.artistName)) {
+        if (TextUtils.isEmpty(song.title) && song.getArtistNames().isEmpty()) {
             appWidgetView.setViewVisibility(R.id.media_titles, View.INVISIBLE);
         } else {
             appWidgetView.setViewVisibility(R.id.media_titles, View.VISIBLE);

--- a/app/src/main/java/com/dkanada/gramophone/views/widgets/AppWidgetClassic.java
+++ b/app/src/main/java/com/dkanada/gramophone/views/widgets/AppWidgetClassic.java
@@ -68,7 +68,7 @@ public class AppWidgetClassic extends BaseAppWidget {
         final boolean isPlaying = service.isPlaying();
         final Song song = service.queueManager.getCurrentSong();
 
-        if (TextUtils.isEmpty(song.title) && TextUtils.isEmpty(song.artistName)) {
+        if (TextUtils.isEmpty(song.title) && song.getArtistNames().isEmpty()) {
             appWidgetView.setViewVisibility(R.id.media_titles, View.INVISIBLE);
         } else {
             appWidgetView.setViewVisibility(R.id.media_titles, View.VISIBLE);

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -20,6 +20,7 @@
     <string name="action_delete">Löschen</string>
     <string name="albums">Alben</string>
     <string name="artists">Interpreten</string>
+    <string name="albumartists">Album-Interpreten</string>
     <string name="genres">Genres</string>
     <string name="songs">Titel</string>
     <string name="playlists">Wiedergabelisten</string>

--- a/app/src/main/res/values-en-rCA/strings.xml
+++ b/app/src/main/res/values-en-rCA/strings.xml
@@ -20,6 +20,7 @@
     <string name="action_delete">Delete</string>
     <string name="albums">Albums</string>
     <string name="artists">Artists</string>
+    <string name="albumartists">Album Artists</string>
     <string name="songs">Songs</string>
     <string name="playlists">Playlists</string>
     <string name="unplayable_file">Couldn\u2019t play this song.</string>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -20,6 +20,7 @@
     <string name="action_delete">Delete</string>
     <string name="albums">Albums</string>
     <string name="artists">Artists</string>
+    <string name="albumartists">Album Artists</string>
     <string name="genres">Genres</string>
     <string name="songs">Songs</string>
     <string name="playlists">Playlists</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,6 +47,7 @@
 
     <string name="albums">Albums</string>
     <string name="artists">Artists</string>
+    <string name="albumartists">Album Artists</string>
     <string name="genres">Genres</string>
     <string name="songs">Songs</string>
     <string name="playlists">Playlists</string>


### PR DESCRIPTION
In response to feature request #198.

This makes it necessary to differentiate between artists and album artists so I created an album artist fragment. The assumption is that at most one albumartist is set but multiple artists in the artist tag are possible.

I also added a GetSearchHintsAsync call to the search activity because GetItemsAsync will not return artists with no albums. GetSearchHintsAsync does not work well with albums though so I split the search into two calls, GetSearchHintsAsync  for artists and GetItemsAsync  for albums and songs. There might be a better way to do this but this is the only way I could make it work.
This should solve issue #176.