### PR TITLE
Fix crash when animator has already started

### DIFF
--- a/app/src/main/java/com/dkanada/gramophone/fragments/player/AbsPlayerFragment.java
+++ b/app/src/main/java/com/dkanada/gramophone/fragments/player/AbsPlayerFragment.java
@@ -1,5 +1,6 @@
 package com.dkanada.gramophone.fragments.player;
 
+import android.animation.AnimatorSet;
 import android.content.Context;
 import android.view.MenuItem;
 import android.view.View;
@@ -25,6 +26,8 @@ import com.dkanada.gramophone.util.NavigationUtil;
 
 public abstract class AbsPlayerFragment extends AbsMusicServiceFragment implements Toolbar.OnMenuItemClickListener, PaletteColorHolder {
     private static boolean isToolbarShown = true;
+
+    protected static AnimatorSet currentAnimatorSet = null;
 
     private Callbacks callbacks;
 

--- a/app/src/main/java/com/dkanada/gramophone/fragments/player/card/CardPlayerFragment.java
+++ b/app/src/main/java/com/dkanada/gramophone/fragments/player/card/CardPlayerFragment.java
@@ -17,6 +17,7 @@ import android.widget.ImageView;
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.lifecycle.Lifecycle;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -436,8 +437,11 @@ public class CardPlayerFragment extends AbsPlayerFragment implements PlayerAlbum
 
         @Override
         public void animateColorChange(int newColor) {
+            if (!fragment.getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.RESUMED)) return;
+            if (currentAnimatorSet!=null) currentAnimatorSet.cancel();
             binding.playerSlidingLayout.setBackgroundColor(fragment.lastColor);
-            createDefaultColorChangeAnimatorSet(newColor).start();
+            currentAnimatorSet = createDefaultColorChangeAnimatorSet(newColor);
+            currentAnimatorSet.start();
         }
     }
 
@@ -467,13 +471,13 @@ public class CardPlayerFragment extends AbsPlayerFragment implements PlayerAlbum
 
         @Override
         public void animateColorChange(int newColor) {
+            if (!fragment.getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.RESUMED)) return;
+            if (currentAnimatorSet!=null) currentAnimatorSet.cancel();
             binding.playerSlidingLayout.setBackgroundColor(fragment.lastColor);
-
-            AnimatorSet animatorSet = createDefaultColorChangeAnimatorSet(newColor);
-            animatorSet.play(ViewUtil.createBackgroundColorTransition(binding.playerToolbar, fragment.lastColor, newColor))
+            currentAnimatorSet = createDefaultColorChangeAnimatorSet(newColor);
+            currentAnimatorSet.play(ViewUtil.createBackgroundColorTransition(binding.playerToolbar, fragment.lastColor, newColor))
                     .with(ViewUtil.createBackgroundColorTransition(fragment.getView().findViewById(R.id.status_bar), ThemeUtil.getColorDark(fragment.lastColor), ThemeUtil.getColorDark(newColor)));
-
-            animatorSet.start();
+            currentAnimatorSet.start();
         }
     }
 }

--- a/app/src/main/java/com/dkanada/gramophone/fragments/player/flat/FlatPlayerFragment.java
+++ b/app/src/main/java/com/dkanada/gramophone/fragments/player/flat/FlatPlayerFragment.java
@@ -15,6 +15,7 @@ import android.widget.ImageView;
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.lifecycle.Lifecycle;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -423,7 +424,10 @@ public class FlatPlayerFragment extends AbsPlayerFragment implements PlayerAlbum
 
         @Override
         public void animateColorChange(int newColor) {
-            createDefaultColorChangeAnimatorSet(newColor).start();
+            if (!fragment.getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.RESUMED)) return;
+            if (currentAnimatorSet!=null) currentAnimatorSet.cancel();
+            currentAnimatorSet = createDefaultColorChangeAnimatorSet(newColor);
+            currentAnimatorSet.start();
         }
     }
 
@@ -450,9 +454,11 @@ public class FlatPlayerFragment extends AbsPlayerFragment implements PlayerAlbum
 
         @Override
         public void animateColorChange(int newColor) {
-            AnimatorSet animatorSet = createDefaultColorChangeAnimatorSet(newColor);
-            animatorSet.play(ViewUtil.createBackgroundColorTransition(binding.playerToolbar, fragment.lastColor, newColor));
-            animatorSet.start();
+            if (!fragment.getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.RESUMED)) return;
+            if (currentAnimatorSet!=null) currentAnimatorSet.cancel();
+            currentAnimatorSet = createDefaultColorChangeAnimatorSet(newColor);
+            currentAnimatorSet.play(ViewUtil.createBackgroundColorTransition(binding.playerToolbar, fragment.lastColor, newColor));
+            currentAnimatorSet.start();
         }
     }
 }


### PR DESCRIPTION
AnimateColorChange did not check wether the animation might already be running, resulting in occasional crashes.

fixes dkanada/gelli#236